### PR TITLE
Adds diagnostic and event stream statistics

### DIFF
--- a/core/src/main/java/com/tcn/exile/config/DiagnosticsService.java
+++ b/core/src/main/java/com/tcn/exile/config/DiagnosticsService.java
@@ -160,7 +160,7 @@ public class DiagnosticsService {
   }
 
   private Hardware collectHardwareInfo() {
-    String model = System.getenv("HOSTNAME");
+    String model = System.getenv("HOSTNAME") != null ? System.getenv("HOSTNAME") : "Unknown";
     String manufacturer = "Unknown";
     String serialNumber = "Unknown";
     String uuid = "Unknown";
@@ -531,6 +531,7 @@ public class DiagnosticsService {
   }
 
   public com.tcn.exile.models.DiagnosticsResult collectSerdeableDiagnostics() {
+    printDiagnosticsToTerminal();
     return com.tcn.exile.models.DiagnosticsResult.fromProto(collectSystemDiagnostics());
   }
 

--- a/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientJobStream.java
+++ b/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientJobStream.java
@@ -212,6 +212,8 @@ public class GateClientJobStream extends GateClientAbstract
         plugin.logger(value.getJobId(), value.getLogging());
       } else if (value.hasExecuteLogic()) {
         plugin.executeLogic(value.getJobId(), value.getExecuteLogic());
+      } else if (value.hasDiagnostics()) {
+        plugin.runDiagnostics(value.getJobId(), value.getDiagnostics());
       } else {
         log.error(
             LogCategory.GRPC, "UnknownJobType", "Unknown job type: {}", value.getUnknownFields());

--- a/core/src/main/java/com/tcn/exile/plugin/PluginInterface.java
+++ b/core/src/main/java/com/tcn/exile/plugin/PluginInterface.java
@@ -97,6 +97,16 @@ public interface PluginInterface {
   void logger(String jobId, StreamJobsResponse.LoggingRequest log);
 
   void executeLogic(String jobId, StreamJobsResponse.ExecuteLogicRequest executeLogic);
+  
+  /**
+   * Run system diagnostics and collect detailed information about the system
+   * environment, JVM settings, memory usage, container details, and database connections.
+   * The resulting diagnostics data is submitted back to the gate service.
+   *
+   * @param jobId The ID of the job
+   * @param diagnosticsRequest The diagnostics request details
+   */
+  void runDiagnostics(String jobId, StreamJobsResponse.DiagnosticsRequest diagnosticsRequest);
 
   void setConfig(PluginConfigEvent config);
 }

--- a/core/src/main/java/com/tcn/exile/plugin/PluginInterface.java
+++ b/core/src/main/java/com/tcn/exile/plugin/PluginInterface.java
@@ -97,11 +97,11 @@ public interface PluginInterface {
   void logger(String jobId, StreamJobsResponse.LoggingRequest log);
 
   void executeLogic(String jobId, StreamJobsResponse.ExecuteLogicRequest executeLogic);
-  
+
   /**
-   * Run system diagnostics and collect detailed information about the system
-   * environment, JVM settings, memory usage, container details, and database connections.
-   * The resulting diagnostics data is submitted back to the gate service.
+   * Run system diagnostics and collect detailed information about the system environment, JVM
+   * settings, memory usage, container details, and database connections. The resulting diagnostics
+   * data is submitted back to the gate service.
    *
    * @param jobId The ID of the job
    * @param diagnosticsRequest The diagnostics request details

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	implementation("io.micronaut:micronaut-http-client")
 	implementation("io.micronaut:micronaut-http-server-netty")
 	implementation("io.micronaut.validation:micronaut-validation")
-
+	implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
 
 	implementation("io.grpc:grpc-core:${grpcVersion}")
 	implementation("io.grpc:grpc-protobuf:${grpcVersion}")

--- a/demo/src/main/java/com/tcn/exile/demo/single/AdminController.java
+++ b/demo/src/main/java/com/tcn/exile/demo/single/AdminController.java
@@ -1,0 +1,69 @@
+/*
+ *  (C) 2017-2025 TCN Inc. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.tcn.exile.demo.single;
+
+import com.tcn.exile.config.DiagnosticsService;
+import com.tcn.exile.models.DiagnosticsResult;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Controller("/api/admin")
+@Requires(bean = Environment.class)
+@OpenAPIDefinition(tags = {@Tag(name = "admin")})
+public class AdminController {
+
+  private static final Logger log = LoggerFactory.getLogger(AdminController.class);
+
+  @Inject private DiagnosticsService diagnosticsService;
+  @Inject private ConfigChangeWatcher configChangeWatcher;
+
+  /**
+   * Returns system diagnostics information.
+   *
+   * @return DiagnosticsResult containing system diagnostics
+   */
+  @Get("/diagnostics")
+  @Tag(name = "admin")
+  @Produces(MediaType.APPLICATION_JSON)
+  public HttpResponse<DiagnosticsResult> getDiagnostics() {
+    log.info("Collecting diagnostics information");
+    try {
+      // First try to call printDiagnosticsToTerminal which might fail but shows detailed error info
+      diagnosticsService.printDiagnosticsToTerminal();
+
+      // Then get the serializable diagnostics result
+      DiagnosticsResult result = diagnosticsService.collectSerdeableDiagnostics();
+      return HttpResponse.ok(result);
+    } catch (Exception e) {
+      log.error("Failed to collect diagnostics information", e);
+      throw new HttpStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "Failed to collect diagnostics: " + e.getMessage());
+    }
+  }
+}

--- a/demo/src/main/java/com/tcn/exile/demo/single/DemoPlugin.java
+++ b/demo/src/main/java/com/tcn/exile/demo/single/DemoPlugin.java
@@ -31,7 +31,6 @@ import com.tcn.exile.memlogger.MemoryAppenderInstance;
 import com.tcn.exile.models.PluginConfigEvent;
 import com.tcn.exile.plugin.PluginInterface;
 import com.tcn.exile.plugin.PluginStatus;
-import jakarta.inject.Inject;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.List;
@@ -45,13 +44,13 @@ public class DemoPlugin implements PluginInterface, LogShipper {
   GateClient gateClient;
   private PluginConfigEvent pluginConfig;
   private String tenantKey;
-
-  @Inject private DiagnosticsService diagnosticsService;
+  private DiagnosticsService diagnosticsService;
 
   public DemoPlugin(String tenantKey, GateClient gateClient) {
     this.gateClient = gateClient;
     this.running = true;
     this.tenantKey = tenantKey;
+    this.diagnosticsService = new DiagnosticsService();
   }
 
   @Override

--- a/demo/src/main/java/com/tcn/exile/demo/single/DemoPlugin.java
+++ b/demo/src/main/java/com/tcn/exile/demo/single/DemoPlugin.java
@@ -23,6 +23,7 @@ import build.buf.gen.tcnapi.exile.gate.v2.LogRequest;
 import build.buf.gen.tcnapi.exile.gate.v2.StreamJobsResponse;
 import build.buf.gen.tcnapi.exile.gate.v2.SubmitJobResultsRequest;
 import ch.qos.logback.classic.LoggerContext;
+import com.tcn.exile.config.DiagnosticsService;
 import com.tcn.exile.gateclients.UnconfiguredException;
 import com.tcn.exile.gateclients.v2.GateClient;
 import com.tcn.exile.memlogger.LogShipper;
@@ -30,6 +31,7 @@ import com.tcn.exile.memlogger.MemoryAppenderInstance;
 import com.tcn.exile.models.PluginConfigEvent;
 import com.tcn.exile.plugin.PluginInterface;
 import com.tcn.exile.plugin.PluginStatus;
+import jakarta.inject.Inject;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.List;
@@ -43,6 +45,8 @@ public class DemoPlugin implements PluginInterface, LogShipper {
   GateClient gateClient;
   private PluginConfigEvent pluginConfig;
   private String tenantKey;
+
+  @Inject private DiagnosticsService diagnosticsService;
 
   public DemoPlugin(String tenantKey, GateClient gateClient) {
     this.gateClient = gateClient;
@@ -339,5 +343,40 @@ public class DemoPlugin implements PluginInterface, LogShipper {
   public void stop() {
     log.info("Tenant: {} - Stopping shipping logs plugin", tenantKey);
     MemoryAppenderInstance.getInstance().disableLogShipper();
+  }
+
+  @Override
+  public void runDiagnostics(
+      String jobId, StreamJobsResponse.DiagnosticsRequest diagnosticsRequest) {
+    log.info("Tenant: {} - Running diagnostics for job {}", tenantKey, jobId);
+
+    try {
+      build.buf.gen.tcnapi.exile.gate.v2.SubmitJobResultsRequest.DiagnosticsResult diagnostics =
+          null;
+      if (diagnosticsService != null) {
+        diagnostics = diagnosticsService.collectSystemDiagnostics();
+      } else {
+        log.warn("DiagnosticsService is null, cannot collect system diagnostics");
+        // Create empty diagnostics result if service is unavailable
+        diagnostics = SubmitJobResultsRequest.DiagnosticsResult.newBuilder().build();
+      }
+
+      // Submit diagnostics results back to gate
+      gateClient.submitJobResults(
+          SubmitJobResultsRequest.newBuilder()
+              .setJobId(jobId)
+              .setEndOfTransmission(true)
+              .setDiagnosticsResult(diagnostics)
+              .build());
+    } catch (Exception e) {
+      log.error("Error running diagnostics", e);
+      // Return empty diagnostics result on error
+      gateClient.submitJobResults(
+          SubmitJobResultsRequest.newBuilder()
+              .setJobId(jobId)
+              .setEndOfTransmission(true)
+              .setDiagnosticsResult(SubmitJobResultsRequest.DiagnosticsResult.newBuilder().build())
+              .build());
+    }
   }
 }


### PR DESCRIPTION
Exposes JDBC connection details and event stream
statistics via JMX and prints them to the terminal for easier debugging and monitoring.

This change introduces a new diagnostics feature that collects and exposes detailed information about the system's JDBC connections and event streams. This
information can be used to diagnose performance issues and identify potential problems.