### PR TITLE
Increases default timeout for GateClient

### DIFF
--- a/core/src/main/java/com/tcn/exile/gateclients/v2/GateClient.java
+++ b/core/src/main/java/com/tcn/exile/gateclients/v2/GateClient.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 public class GateClient extends GateClientAbstract {
   private static final StructuredLogger log = new StructuredLogger(GateClient.class);
-  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_TIMEOUT_SECONDS = 300;
 
   public GateClient(String tenant, Config currentConfig) {
     super(tenant, currentConfig);

--- a/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientConfiguration.java
+++ b/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientConfiguration.java
@@ -47,7 +47,7 @@ public class GateClientConfiguration extends GateClientAbstract {
     try {
       var client =
           GateServiceGrpc.newBlockingStub(getChannel())
-              .withDeadlineAfter(30, TimeUnit.SECONDS)
+              .withDeadlineAfter(300, TimeUnit.SECONDS)
               .withWaitForReady();
       GetClientConfigurationResponse response =
           client.getClientConfiguration(GetClientConfigurationRequest.newBuilder().build());

--- a/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientPollEvents.java
+++ b/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientPollEvents.java
@@ -52,7 +52,7 @@ public class GateClientPollEvents extends GateClientAbstract {
       }
       var client =
           GateServiceGrpc.newBlockingStub(getChannel())
-              .withDeadlineAfter(30, TimeUnit.SECONDS)
+              .withDeadlineAfter(300, TimeUnit.SECONDS)
               .withWaitForReady();
       var response = client.pollEvents(PollEventsRequest.newBuilder().build());
       if (response.getEventsCount() == 0) {


### PR DESCRIPTION
Increases the default timeout for GateClient operations to 300 seconds.

This change addresses potential issues caused by short timeouts during communication with the Gate service, especially in environments with high latency or under heavy load. The increased timeout provides more resilience and prevents premature termination of requests.

The timeout is applied to all GateClient operations, including configuration retrieval and job stream establishment. Includes logging improvements to provide insight into job stream connection and disconnection events, as well as stream establishment duration.