### PR TITLE
Adjust logging information

### DIFF
--- a/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientConfiguration.java
+++ b/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientConfiguration.java
@@ -35,61 +35,66 @@ public class GateClientConfiguration extends GateClientAbstract {
   protected static final org.slf4j.Logger log =
       org.slf4j.LoggerFactory.getLogger(GateClientConfiguration.class);
 
-  /**
-   * Redacts sensitive information from JSON configuration payload.
-   */
+  /** Redacts sensitive information from JSON configuration payload. */
   private String redactConfigPayloadForLogging(String payload) {
     if (payload == null || payload.isBlank()) {
       return payload;
     }
-    
+
     // Redact password field
-    String redacted = payload.replaceAll("\"database_password\"\\s*:\\s*\"[^\"]*\"", "\"database_password\":\"***REDACTED***\"");
-    
+    String redacted =
+        payload.replaceAll(
+            "\"database_password\"\\s*:\\s*\"[^\"]*\"", "\"database_password\":\"***REDACTED***\"");
+
     // Redact username field
-    redacted = redacted.replaceAll("\"database_username\"\\s*:\\s*\"[^\"]*\"", "\"database_username\":\"***REDACTED***\"");
-    
+    redacted =
+        redacted.replaceAll(
+            "\"database_username\"\\s*:\\s*\"[^\"]*\"", "\"database_username\":\"***REDACTED***\"");
+
     // Redact jdbcUser field
-    redacted = redacted.replaceAll("\"jdbcUser\"\\s*:\\s*\"[^\"]*\"", "\"jdbcUser\":\"***REDACTED***\"");
-    
+    redacted =
+        redacted.replaceAll("\"jdbcUser\"\\s*:\\s*\"[^\"]*\"", "\"jdbcUser\":\"***REDACTED***\"");
+
     // Redact certificate fields
-    redacted = redacted.replaceAll("\"trust_store_cert\"\\s*:\\s*\"[^\"]*\"", "\"trust_store_cert\":\"***CERTIFICATE_REDACTED***\"");
-    redacted = redacted.replaceAll("\"key_store_cert\"\\s*:\\s*\"[^\"]*\"", "\"key_store_cert\":\"***CERTIFICATE_REDACTED***\"");
-    
+    redacted =
+        redacted.replaceAll(
+            "\"trust_store_cert\"\\s*:\\s*\"[^\"]*\"",
+            "\"trust_store_cert\":\"***CERTIFICATE_REDACTED***\"");
+    redacted =
+        redacted.replaceAll(
+            "\"key_store_cert\"\\s*:\\s*\"[^\"]*\"",
+            "\"key_store_cert\":\"***CERTIFICATE_REDACTED***\"");
+
     return redacted;
   }
 
-  /**
-   * Creates a redacted version of PluginConfigEvent for safe logging.
-   */
+  /** Creates a redacted version of PluginConfigEvent for safe logging. */
   private String redactEventForLogging(PluginConfigEvent event) {
     if (event == null) {
       return "null";
     }
-    
-    return String.format("PluginConfigEvent{orgId='%s', orgName='%s', configurationName='%s', configurationPayload='%s', unconfigured=%s}",
+
+    return String.format(
+        "PluginConfigEvent{orgId='%s', orgName='%s', configurationName='%s', configurationPayload='%s', unconfigured=%s}",
         event.getOrgId(),
         event.getOrgName(),
         event.getConfigurationName(),
         redactConfigPayloadForLogging(event.getConfigurationPayload()),
-        event.isUnconfigured()
-    );
+        event.isUnconfigured());
   }
 
-  /**
-   * Creates a redacted version of GetClientConfigurationResponse for safe logging.
-   */
+  /** Creates a redacted version of GetClientConfigurationResponse for safe logging. */
   private String redactResponseForLogging(GetClientConfigurationResponse response) {
     if (response == null) {
       return "null";
     }
-    
-    return String.format("GetClientConfigurationResponse{orgId='%s', orgName='%s', configName='%s', configPayload='%s'}",
+
+    return String.format(
+        "GetClientConfigurationResponse{orgId='%s', orgName='%s', configName='%s', configPayload='%s'}",
         response.getOrgId(),
         response.getOrgName(),
         response.getConfigName(),
-        redactConfigPayloadForLogging(response.getConfigPayload())
-    );
+        redactConfigPayloadForLogging(response.getConfigPayload()));
   }
 
   public GateClientConfiguration(String tenant, Config currentConfig, PluginInterface plugin) {

--- a/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientConfiguration.java
+++ b/core/src/main/java/com/tcn/exile/gateclients/v2/GateClientConfiguration.java
@@ -35,6 +35,63 @@ public class GateClientConfiguration extends GateClientAbstract {
   protected static final org.slf4j.Logger log =
       org.slf4j.LoggerFactory.getLogger(GateClientConfiguration.class);
 
+  /**
+   * Redacts sensitive information from JSON configuration payload.
+   */
+  private String redactConfigPayloadForLogging(String payload) {
+    if (payload == null || payload.isBlank()) {
+      return payload;
+    }
+    
+    // Redact password field
+    String redacted = payload.replaceAll("\"database_password\"\\s*:\\s*\"[^\"]*\"", "\"database_password\":\"***REDACTED***\"");
+    
+    // Redact username field
+    redacted = redacted.replaceAll("\"database_username\"\\s*:\\s*\"[^\"]*\"", "\"database_username\":\"***REDACTED***\"");
+    
+    // Redact jdbcUser field
+    redacted = redacted.replaceAll("\"jdbcUser\"\\s*:\\s*\"[^\"]*\"", "\"jdbcUser\":\"***REDACTED***\"");
+    
+    // Redact certificate fields
+    redacted = redacted.replaceAll("\"trust_store_cert\"\\s*:\\s*\"[^\"]*\"", "\"trust_store_cert\":\"***CERTIFICATE_REDACTED***\"");
+    redacted = redacted.replaceAll("\"key_store_cert\"\\s*:\\s*\"[^\"]*\"", "\"key_store_cert\":\"***CERTIFICATE_REDACTED***\"");
+    
+    return redacted;
+  }
+
+  /**
+   * Creates a redacted version of PluginConfigEvent for safe logging.
+   */
+  private String redactEventForLogging(PluginConfigEvent event) {
+    if (event == null) {
+      return "null";
+    }
+    
+    return String.format("PluginConfigEvent{orgId='%s', orgName='%s', configurationName='%s', configurationPayload='%s', unconfigured=%s}",
+        event.getOrgId(),
+        event.getOrgName(),
+        event.getConfigurationName(),
+        redactConfigPayloadForLogging(event.getConfigurationPayload()),
+        event.isUnconfigured()
+    );
+  }
+
+  /**
+   * Creates a redacted version of GetClientConfigurationResponse for safe logging.
+   */
+  private String redactResponseForLogging(GetClientConfigurationResponse response) {
+    if (response == null) {
+      return "null";
+    }
+    
+    return String.format("GetClientConfigurationResponse{orgId='%s', orgName='%s', configName='%s', configPayload='%s'}",
+        response.getOrgId(),
+        response.getOrgName(),
+        response.getConfigName(),
+        redactConfigPayloadForLogging(response.getConfigPayload())
+    );
+  }
+
   public GateClientConfiguration(String tenant, Config currentConfig, PluginInterface plugin) {
     super(tenant, currentConfig);
     this.plugin = plugin;
@@ -55,8 +112,8 @@ public class GateClientConfiguration extends GateClientAbstract {
       log.debug(
           "Tenant: {} got config response: {} current event: {}",
           this.tenant,
-          response,
-          this.event);
+          redactResponseForLogging(response),
+          redactEventForLogging(this.event));
       var newEvent =
           new PluginConfigEvent(this)
               .setConfigurationName(response.getConfigName())
@@ -68,7 +125,7 @@ public class GateClientConfiguration extends GateClientAbstract {
         log.debug(
             "Tenant: {} - Received new configuration event: {}, update plugin config",
             tenant,
-            newEvent);
+            redactEventForLogging(newEvent));
         event = newEvent;
         this.plugin.setConfig(event);
       }


### PR DESCRIPTION
This pull request enhances logging security in the `GateClientConfiguration` class by ensuring that sensitive information is redacted from configuration payloads and related log entries. The main focus is on preventing credentials and certificates from appearing in logs, improving compliance and reducing risk of information leakage.

Sensitive data redaction for logging:

* Added `redactConfigPayloadForLogging`, `redactEventForLogging`, and `redactResponseForLogging` helper methods to redact sensitive fields (like passwords, usernames, and certificates) from configuration payloads and event/response objects before logging.
* Updated all debug log statements in the `start` method to use the new redaction methods, ensuring that sensitive data is never written to logs. [[1]](diffhunk://#diff-d02160a1e7992cb5c86e00261047d53f81fed4871bb67be83b71a97ad59fe4d8L58-R121) [[2]](diffhunk://#diff-d02160a1e7992cb5c86e00261047d53f81fed4871bb67be83b71a97ad59fe4d8L71-R133)