### PR TITLE
bench: WorkStream v3 throughput harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+# WorkStream v3 benchmark harness.
+#
+# Runs the Go benchmark server (from the exile/exile repo) against the sati
+# Java benchmark harness to measure end-to-end throughput and latency.
+#
+# Usage:
+#   make benchmark                          # runs all scenarios, 60 s each
+#   make benchmark SCENARIO=mixed-steady   # run one scenario
+#   make benchmark DURATION=30             # shorter run
+#
+# Env overrides:
+#   EXILE_REPO            path to exile/exile git repo
+#                         (default: ../../tcn/exile/exile)
+#   BENCH_CERTS           cert output dir (default: /tmp/sati-benchmark/certs)
+#   BENCH_REPORTS         JSON report dir (default: benchmarks/results)
+#   MAX_CONCURRENCY       client maxConcurrency (default: 5 — the current sati default)
+#   JOB_LATENCY_MS        plugin latency per job
+#   EVENT_LATENCY_MS      plugin latency per event
+#   PLUGIN_ERROR_RATE     0..1 probability the plugin throws per item
+#
+# Java is provisioned via SDKMAN using this repo's .sdkmanrc (currently
+# 21.0.9-amzn). Requires SDKMAN installed at $HOME/.sdkman/
+# (`curl -s https://get.sdkman.io | bash`). Works with the stock macOS
+# `make` (GNU Make 3.81) — recipes wrap their bodies in `bash -c '...'`
+# so SDKMAN's `sdk env` stays in effect for the whole recipe.
+
+EXILE_REPO        ?= $(abspath $(CURDIR)/../../tcn/exile/exile)
+BENCH_CERTS       ?= /tmp/sati-benchmark/certs
+BENCH_REPORTS     ?= $(CURDIR)/benchmarks/results
+BENCH_SRV_BIN     ?= $(CURDIR)/benchmarks/build/gatev3-benchmark-server
+BENCH_SRV_LOG     ?= $(CURDIR)/benchmarks/build/gatev3-benchmark-server.log
+BENCH_SRV_PID     ?= $(CURDIR)/benchmarks/build/gatev3-benchmark-server.pid
+GRPC_PORT         ?= 50051
+HTTP_PORT         ?= 50052
+DURATION          ?= 60
+SCENARIO          ?= all
+MAX_CONCURRENCY   ?= 5
+JOB_LATENCY_MS    ?= 10
+EVENT_LATENCY_MS  ?= 5
+PLUGIN_ERROR_RATE ?= 0.0
+
+.PHONY: benchmark build-bench-server bench-clean check-sdkman
+
+check-sdkman:
+	@bash -c ' \
+		set -e; \
+		if [[ ! -s "$$HOME/.sdkman/bin/sdkman-init.sh" ]]; then \
+			echo "ERROR: SDKMAN not found at $$HOME/.sdkman/. Install: curl -s https://get.sdkman.io | bash"; \
+			exit 1; \
+		fi; \
+		source "$$HOME/.sdkman/bin/sdkman-init.sh"; \
+		sdk env >/dev/null; \
+		echo "sdkman ok — JAVA_HOME=$$JAVA_HOME"; \
+		echo "          java: $$(java -version 2>&1 | head -1)"; \
+	'
+
+benchmark: build-bench-server
+	@bash -c ' \
+		set -eo pipefail; \
+		if [[ ! -s "$$HOME/.sdkman/bin/sdkman-init.sh" ]]; then \
+			echo "ERROR: SDKMAN not found. Run: make check-sdkman"; exit 1; \
+		fi; \
+		source "$$HOME/.sdkman/bin/sdkman-init.sh"; \
+		sdk env >/dev/null; \
+		echo "==> JAVA_HOME=$$JAVA_HOME"; \
+		echo "==> generating certs"; \
+		mkdir -p "$(BENCH_CERTS)"; \
+		"$(BENCH_SRV_BIN)" --generate-certs-only --certs="$(BENCH_CERTS)"; \
+		echo "==> starting benchmark server"; \
+		mkdir -p "$(dir $(BENCH_SRV_LOG))"; \
+		"$(BENCH_SRV_BIN)" \
+			--certs="$(BENCH_CERTS)" \
+			--grpc=":$(GRPC_PORT)" \
+			--http=":$(HTTP_PORT)" \
+			> "$(BENCH_SRV_LOG)" 2>&1 & \
+		srv_pid=$$!; \
+		echo $$srv_pid > "$(BENCH_SRV_PID)"; \
+		trap "kill $$srv_pid 2>/dev/null || true; rm -f \"$(BENCH_SRV_PID)\"" EXIT INT TERM; \
+		echo "==> running benchmark harness (scenario=$(SCENARIO), duration=$(DURATION)s)"; \
+		./gradlew :benchmarks:run -q --args="--certs=$(BENCH_CERTS) --grpc-host=localhost --grpc-port=$(GRPC_PORT) --control-url=http://localhost:$(HTTP_PORT) --duration=$(DURATION) --reports=$(BENCH_REPORTS) --scenario=$(SCENARIO) --max-concurrency=$(MAX_CONCURRENCY) --job-latency-ms=$(JOB_LATENCY_MS) --event-latency-ms=$(EVENT_LATENCY_MS) --plugin-error-rate=$(PLUGIN_ERROR_RATE)"; \
+		echo "==> server log: $(BENCH_SRV_LOG)"; \
+	'
+
+build-bench-server:
+	@bash -c ' \
+		set -e; \
+		if [[ ! -d "$(EXILE_REPO)" ]]; then \
+			echo "ERROR: EXILE_REPO=$(EXILE_REPO) not found. Set it to the path of your exile/exile clone."; \
+			exit 1; \
+		fi; \
+		mkdir -p "$(dir $(BENCH_SRV_BIN))"; \
+		echo "==> building benchmark server from $(EXILE_REPO)"; \
+		cd "$(EXILE_REPO)" && go build -o "$(BENCH_SRV_BIN)" ./gatev3-benchmark-server; \
+	'
+
+bench-clean:
+	@rm -rf "$(BENCH_CERTS)" "$(BENCH_SRV_BIN)" "$(BENCH_SRV_PID)" "$(BENCH_SRV_LOG)"
+	@rm -rf "$(BENCH_REPORTS)"
+	@echo "benchmark artifacts cleaned"

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,2 @@
+build/
+results/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -85,10 +85,31 @@ jq '.scenarios."mixed-steady".throughput' baseline.json
 jq '.scenarios."mixed-steady".throughput' after-c1.json
 ```
 
-## Current state (as of 2026-04-15)
+## Baseline (2026-04-15 — before any S/C issue lands)
 
-Baseline numbers will be recorded here once the first run completes — see
-`benchmarks/results/baseline-<date>.json`.
+60 s per scenario, `maxConcurrency=5` (current sati default), plugin latency
+10 ms/job and 5 ms/event, ±jitter. Full report: `baseline-2026-04-15.json`.
+
+| Scenario                | jobs/s | events/s | job p95 | event p95 |
+|-------------------------|-------:|---------:|--------:|----------:|
+| `burst-events-10k`      | 0      | 993.2    | —       | 6 ms      |
+| `events-ramp-200rps`    | 0      | 199.9    | —       | 6 ms      |
+| `mixed-steady`          | 95.0   | 499.2    | 14 ms   | 6 ms      |
+| `sustained-jobs-100rps` | 95.3   | 0        | 14 ms   | —         |
+
+### Reading the baseline
+
+- Jobs sustain ~95/s against a 100/s injection target — client is keeping up
+  at this rate and latency.
+- Events reach ~993/s against a 1000/s target in `burst-events-10k` despite
+  the 500 ms idle backoff, because the synthetic generator produces events in
+  100 ms chunks that keep the 32-item batches saturated. The real-world
+  sparse-events pattern (where the queue regularly has < 32 items waiting)
+  isn't exercised by this scenario set yet — adding a `sparse-events-5rps`
+  scenario would illuminate the S3 fix more directly.
+- No scenario here saturates the `maxConcurrency=5` cap because the plugin
+  latency is too low. Rerun with `EVENT_LATENCY_MS=200` (or inject `info` /
+  `search_records` jobs at higher rates) to see the ceiling.
 
 ## Faithfulness caveat
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,106 @@
+# WorkStream v3 Benchmark Harness
+
+End-to-end performance harness for the sati Java client talking to a
+benchmark-only reimplementation of the exile gatev3 WorkerService. Used to
+establish a baseline before the WorkStream v3 throughput work (epic:
+`exile/-/epics/9`) and measure each improvement as it lands.
+
+## What's here
+
+- `benchmarks/` (this subproject): Java harness that drives load through the
+  real `ExileClient` and records latency/throughput.
+- `../../tcn/exile/exile/gatev3-benchmark-server/`: Go server that faithfully
+  reproduces the current gatev3 WorkerService behaviour (hardcoded 32-entity
+  event batches, 500 ms idle backoff, concurrent `stream.Send`, synchronous
+  result persist when `--db-latency` is set). No Postgres, no Redis.
+
+## Prerequisites
+
+- JDK 21+
+- Go 1.24+
+- A local clone of `git.tcncloud.net/exile/exile` alongside sati:
+  ```
+  $HOME/dev/tcncloud/sati          <- this repo
+  $HOME/dev/tcn/exile/exile        <- or elsewhere: set EXILE_REPO
+  ```
+
+## Run it
+
+```bash
+make benchmark                               # all scenarios, 60 s each
+make benchmark SCENARIO=mixed-steady         # one scenario
+make benchmark DURATION=30                   # shorter run
+make benchmark MAX_CONCURRENCY=50            # what happens at higher concurrency
+make benchmark JOB_LATENCY_MS=200            # slower plugin
+```
+
+Reports are written to `benchmarks/results/<timestamp>.json` and also printed
+to stdout.
+
+## Scenarios
+
+| Name                     | What it drives | What we're measuring |
+|--------------------------|----------------|----------------------|
+| `burst-events-10k`       | 1000 events/s pushed by the server generator | event throughput ceiling (current: ~64/s due to 500 ms backoff + batch=32) |
+| `sustained-jobs-100rps`  | 100 job/s injected via `/inject-job` | job-only RTT + concurrency cap |
+| `mixed-steady`           | 100 jobs/s + 500 events/s simultaneously | priority fairness — jobs vs events |
+| `events-ramp-200rps`     | 200 events/s sustained | pair with `EVENT_LATENCY_MS=200` to stress the concurrency cap (current default `maxConcurrency=5` → ~25 items/s with a 200 ms plugin) |
+
+## Report shape
+
+```json
+{
+  "metadata": {
+    "timestamp": "2026-04-15T...",
+    "grpc_host": "localhost:50051",
+    "max_concurrency": 5,
+    "duration_s": 60,
+    "job_latency_ms": 10,
+    ...
+  },
+  "scenarios": {
+    "mixed-steady": {
+      "duration_s": 60.0,
+      "throughput": { "jobs_per_s": 100.0, "events_per_s": 60.0 },
+      "total":      { "jobs": 6000, "events": 3600 },
+      "errors":     { "jobs": 0, "events": 0 },
+      "job_latency_ms":   { "p50": 12, "p95": 540, "p99": 820, "max": 1024 },
+      "event_latency_ms": { "p50": 7, "p95": 240, "p99": 480, "max": 790 },
+      "server_stats": { "jobs_dispatched": 6000, ... }
+    }
+  }
+}
+```
+
+Latency is **client-side processing time** (from plugin handler entry to exit,
+recorded in `BenchmarkPlugin`). This closely approximates end-to-end latency
+over localhost.
+
+## Comparing runs
+
+Two JSON reports can be diffed by hand or with `jq`:
+
+```bash
+jq '.scenarios."mixed-steady".throughput' baseline.json
+jq '.scenarios."mixed-steady".throughput' after-c1.json
+```
+
+## Current state (as of 2026-04-15)
+
+Baseline numbers will be recorded here once the first run completes — see
+`benchmarks/results/baseline-<date>.json`.
+
+## Faithfulness caveat
+
+The Go benchmark server is a **simulator**, not the real gatev3 package —
+`*exiledb.Repository` is a concrete struct (not an interface), so we can't
+run the real gatev3 GrpcApi without Postgres. The simulator reproduces the
+observable behaviour of each bottleneck documented in the epic:
+
+- `eventBatchSize = 32` (hardcoded, ignores `pull.MaxItems`)
+- 500 ms idle backoff in the event poller
+- Concurrent `stream.Send` from heartbeat / lease / recv goroutines
+- Synchronous "DB write" on result (via `--db-latency`)
+
+When the server-side fixes (S1, S2, S3) land, update the simulator to match
+and re-run to confirm the gains show up.

--- a/benchmarks/baseline-2026-04-15.json
+++ b/benchmarks/baseline-2026-04-15.json
@@ -1,0 +1,97 @@
+{
+  "metadata": {
+    "timestamp": "2026-04-15T19:05:51.880873Z",
+    "grpc_host": "localhost:50051",
+    "max_concurrency": 5,
+    "duration_s": 60,
+    "job_latency_ms": 10,
+    "event_latency_ms": 5,
+    "plugin_error_rate": 0.0
+  },
+  "scenarios": {
+    "burst-events-10k": {
+      "duration_s": 60.11,
+      "throughput": {"jobs_per_s": 0.00, "events_per_s": 993.16},
+      "total": {"jobs": 0, "events": 59700},
+      "errors": {"jobs": 0, "events": 0},
+      "job_latency_ms": {"p50": 0, "p95": 0, "p99": 0, "max": 0},
+      "event_latency_ms": {"p50": 5, "p95": 6, "p99": 7, "max": 13},
+      "server_stats": {
+        "current_connected": 1,
+        "current_inflight": 163,
+        "event_queue_depth": 400,
+        "event_rate_target": 0,
+        "events_acked": 59700,
+        "events_dispatched": 59700,
+        "events_nacked": 0,
+        "jobs_accepted": 0,
+        "jobs_dispatched": 0,
+        "jobs_errored": 0,
+        "pull_count": 59700
+      }
+    },
+    "events-ramp-200rps": {
+      "duration_s": 60.02,
+      "throughput": {"jobs_per_s": 0.00, "events_per_s": 199.94},
+      "total": {"jobs": 0, "events": 12000},
+      "errors": {"jobs": 0, "events": 0},
+      "job_latency_ms": {"p50": 0, "p95": 0, "p99": 0, "max": 0},
+      "event_latency_ms": {"p50": 5, "p95": 6, "p99": 7, "max": 8},
+      "server_stats": {
+        "current_connected": 1,
+        "current_inflight": 100,
+        "event_queue_depth": 0,
+        "event_rate_target": 0,
+        "events_acked": 12000,
+        "events_dispatched": 12000,
+        "events_nacked": 0,
+        "jobs_accepted": 0,
+        "jobs_dispatched": 0,
+        "jobs_errored": 0,
+        "pull_count": 12000
+      }
+    },
+    "mixed-steady": {
+      "duration_s": 60.10,
+      "throughput": {"jobs_per_s": 95.01, "events_per_s": 499.16},
+      "total": {"jobs": 5710, "events": 30000},
+      "errors": {"jobs": 0, "events": 0},
+      "job_latency_ms": {"p50": 10, "p95": 14, "p99": 15, "max": 15},
+      "event_latency_ms": {"p50": 5, "p95": 6, "p99": 7, "max": 14},
+      "server_stats": {
+        "current_connected": 1,
+        "current_inflight": 57,
+        "event_queue_depth": 50,
+        "event_rate_target": 0,
+        "events_acked": 30000,
+        "events_dispatched": 30000,
+        "events_nacked": 0,
+        "jobs_accepted": 5710,
+        "jobs_dispatched": 5710,
+        "jobs_errored": 0,
+        "pull_count": 35710
+      }
+    },
+    "sustained-jobs-100rps": {
+      "duration_s": 60.04,
+      "throughput": {"jobs_per_s": 95.27, "events_per_s": 0.00},
+      "total": {"jobs": 5720, "events": 0},
+      "errors": {"jobs": 0, "events": 0},
+      "job_latency_ms": {"p50": 10, "p95": 14, "p99": 15, "max": 16},
+      "event_latency_ms": {"p50": 0, "p95": 0, "p99": 0, "max": 0},
+      "server_stats": {
+        "current_connected": 1,
+        "current_inflight": 10,
+        "event_queue_depth": 0,
+        "event_rate_target": 0,
+        "events_acked": 0,
+        "events_dispatched": 0,
+        "events_nacked": 0,
+        "jobs_accepted": 5720,
+        "jobs_dispatched": 5720,
+        "jobs_errored": 0,
+        "pull_count": 5720
+      }
+    }
+  }
+}

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+	id("application")
+}
+
+application {
+	mainClass = "com.tcn.exile.bench.Main"
+}
+
+dependencies {
+	implementation(project(":core"))
+	implementation("io.grpc:grpc-netty-shaded:${grpcVersion}")
+	implementation("ch.qos.logback:logback-classic:1.5.18")
+}
+
+// Not a published artifact — disable the publish tasks that allprojects { ... }
+// in the root build applies to every subproject.
+tasks.withType(AbstractPublishToMaven).configureEach { enabled = false }
+
+run {
+	// Accept CLI args via `./gradlew :benchmarks:run --args="..."`
+	standardInput = System.in
+}

--- a/benchmarks/src/main/java/com/tcn/exile/bench/BenchmarkPlugin.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/BenchmarkPlugin.java
@@ -1,0 +1,176 @@
+package com.tcn.exile.bench;
+
+import com.tcn.exile.handler.PluginBase;
+import com.tcn.exile.model.*;
+import com.tcn.exile.model.event.*;
+import com.tcn.exile.service.ConfigService;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A Plugin whose handler methods sleep for a configurable, jittered duration to simulate work. Each
+ * handler records its processing latency into the appropriate LatencyHistogram.
+ *
+ * <p>All methods are thread-safe: handlers are invoked from virtual threads by {@link
+ * com.tcn.exile.ExileClient}.
+ */
+public final class BenchmarkPlugin extends PluginBase {
+
+  private final long jobLatencyNanos;
+  private final long jobJitterNanos;
+  private final long eventLatencyNanos;
+  private final long eventJitterNanos;
+  private final double errorRate;
+
+  final LatencyHistogram jobLatency;
+  final LatencyHistogram eventLatency;
+
+  BenchmarkPlugin(
+      long jobLatencyNanos,
+      long jobJitterNanos,
+      long eventLatencyNanos,
+      long eventJitterNanos,
+      double errorRate) {
+    this.jobLatencyNanos = jobLatencyNanos;
+    this.jobJitterNanos = jobJitterNanos;
+    this.eventLatencyNanos = eventLatencyNanos;
+    this.eventJitterNanos = eventJitterNanos;
+    this.errorRate = errorRate;
+    this.jobLatency = new LatencyHistogram(65_536);
+    this.eventLatency = new LatencyHistogram(65_536);
+  }
+
+  @Override
+  public boolean onConfig(ConfigService.ClientConfiguration config) {
+    return true;
+  }
+
+  // --- Jobs ---
+  @Override
+  public List<Pool> listPools() throws Exception {
+    doJob();
+    return List.of();
+  }
+
+  @Override
+  public Pool getPoolStatus(String poolId) throws Exception {
+    doJob();
+    return new Pool(poolId, "bench-pool", Pool.PoolStatus.READY, 0);
+  }
+
+  @Override
+  public Page<DataRecord> getPoolRecords(String poolId, String pageToken, int pageSize)
+      throws Exception {
+    doJob();
+    return new Page<>(List.of(), "");
+  }
+
+  @Override
+  public Page<DataRecord> searchRecords(List<Filter> filters, String pageToken, int pageSize)
+      throws Exception {
+    doJob();
+    return new Page<>(List.of(), "");
+  }
+
+  @Override
+  public List<Field> getRecordFields(String poolId, String recordId, List<String> fieldNames)
+      throws Exception {
+    doJob();
+    return List.of();
+  }
+
+  @Override
+  public boolean setRecordFields(String poolId, String recordId, List<Field> fields)
+      throws Exception {
+    doJob();
+    return true;
+  }
+
+  @Override
+  public String createPayment(String poolId, String recordId, Map<String, Object> paymentData)
+      throws Exception {
+    doJob();
+    return "bench-payment-id";
+  }
+
+  @Override
+  public DataRecord popAccount(String poolId, String recordId) throws Exception {
+    doJob();
+    return new DataRecord(poolId, recordId, Map.of());
+  }
+
+  @Override
+  public Map<String, Object> executeLogic(String logicName, Map<String, Object> parameters)
+      throws Exception {
+    doJob();
+    return Map.of();
+  }
+
+  // --- Events ---
+  @Override
+  public void onAgentCall(AgentCallEvent event) throws Exception {
+    doEvent();
+  }
+
+  @Override
+  public void onTelephonyResult(TelephonyResultEvent event) throws Exception {
+    doEvent();
+  }
+
+  @Override
+  public void onAgentResponse(AgentResponseEvent event) throws Exception {
+    doEvent();
+  }
+
+  @Override
+  public void onTransferInstance(TransferInstanceEvent event) throws Exception {
+    doEvent();
+  }
+
+  @Override
+  public void onCallRecording(CallRecordingEvent event) throws Exception {
+    doEvent();
+  }
+
+  @Override
+  public void onTask(TaskEvent event) throws Exception {
+    doEvent();
+  }
+
+  // --- Internals ---
+  private void doJob() throws Exception {
+    long start = System.nanoTime();
+    try {
+      sleep(jobLatencyNanos, jobJitterNanos);
+      maybeError();
+    } finally {
+      jobLatency.record(System.nanoTime() - start);
+    }
+  }
+
+  private void doEvent() throws Exception {
+    long start = System.nanoTime();
+    try {
+      sleep(eventLatencyNanos, eventJitterNanos);
+      maybeError();
+    } finally {
+      eventLatency.record(System.nanoTime() - start);
+    }
+  }
+
+  private void sleep(long base, long jitter) throws InterruptedException {
+    long d = base;
+    if (jitter > 0) {
+      d += ThreadLocalRandom.current().nextLong(-jitter, jitter + 1);
+    }
+    if (d <= 0) return;
+    Thread.sleep(d / 1_000_000, (int) (d % 1_000_000));
+  }
+
+  private void maybeError() throws Exception {
+    if (errorRate > 0 && ThreadLocalRandom.current().nextDouble() < errorRate) {
+      throw new RuntimeException("synthetic benchmark error");
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/tcn/exile/bench/ControlClient.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/ControlClient.java
@@ -1,0 +1,143 @@
+package com.tcn.exile.bench;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** HTTP client for the Go benchmark server's control endpoints. */
+final class ControlClient {
+  private final HttpClient http;
+  private final String base;
+
+  ControlClient(String baseUrl) {
+    this.http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    this.base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
+
+  void reset() throws IOException, InterruptedException {
+    post("/reset");
+  }
+
+  void setEventRate(int rps) throws IOException, InterruptedException {
+    post("/set-event-rate?rps=" + rps);
+  }
+
+  /** Returns dispatched count from server. Blocks until request completes. */
+  int injectJobs(String type, int count) throws IOException, InterruptedException {
+    var body = post("/inject-job?type=" + type + "&count=" + count);
+    // Response: "ok: dispatched=N"
+    int idx = body.indexOf('=');
+    return idx >= 0 ? Integer.parseInt(body.substring(idx + 1).trim()) : 0;
+  }
+
+  /** Waits until server /health returns 200, up to the given timeout. */
+  boolean waitHealthy(Duration timeout) {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      try {
+        var resp =
+            http.send(
+                HttpRequest.newBuilder(URI.create(base + "/health"))
+                    .timeout(Duration.ofSeconds(1))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() == 200) return true;
+      } catch (Exception ignored) {
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
+    return false;
+  }
+
+  /** Returns a naive JSON parse as a flat Map of the /stats endpoint. */
+  Map<String, Object> stats() throws IOException, InterruptedException {
+    var body = get("/stats");
+    return parseFlatJson(body);
+  }
+
+  private String get(String path) throws IOException, InterruptedException {
+    var resp =
+        http.send(
+            HttpRequest.newBuilder(URI.create(base + path))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    if (resp.statusCode() >= 300) {
+      throw new IOException("GET " + path + " -> " + resp.statusCode() + ": " + resp.body());
+    }
+    return resp.body();
+  }
+
+  private String post(String path) throws IOException, InterruptedException {
+    var resp =
+        http.send(
+            HttpRequest.newBuilder(URI.create(base + path))
+                .timeout(Duration.ofSeconds(10))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    if (resp.statusCode() >= 300) {
+      throw new IOException("POST " + path + " -> " + resp.statusCode() + ": " + resp.body());
+    }
+    return resp.body();
+  }
+
+  /**
+   * Extremely naive JSON parser that handles only flat objects with number and string values — the
+   * /stats response shape. Avoids pulling a JSON library for a single call site.
+   */
+  static Map<String, Object> parseFlatJson(String s) {
+    Map<String, Object> out = new LinkedHashMap<>();
+    int i = 0;
+    while (i < s.length() && s.charAt(i) != '{') i++;
+    if (i >= s.length()) return out;
+    i++; // skip {
+    while (i < s.length()) {
+      // skip whitespace + commas
+      while (i < s.length() && (Character.isWhitespace(s.charAt(i)) || s.charAt(i) == ',')) i++;
+      if (i >= s.length() || s.charAt(i) == '}') break;
+      if (s.charAt(i) != '"') {
+        i++;
+        continue;
+      }
+      int keyStart = ++i;
+      while (i < s.length() && s.charAt(i) != '"') i++;
+      String key = s.substring(keyStart, i);
+      i++; // skip closing "
+      while (i < s.length() && (Character.isWhitespace(s.charAt(i)) || s.charAt(i) == ':')) i++;
+      // parse value: string or number (no nested objects expected).
+      if (i < s.length() && s.charAt(i) == '"') {
+        int valStart = ++i;
+        while (i < s.length() && s.charAt(i) != '"') i++;
+        out.put(key, s.substring(valStart, i));
+        i++;
+      } else {
+        int valStart = i;
+        while (i < s.length() && s.charAt(i) != ',' && s.charAt(i) != '}') i++;
+        String raw = s.substring(valStart, i).trim();
+        try {
+          out.put(key, Long.parseLong(raw));
+        } catch (NumberFormatException nfe) {
+          try {
+            out.put(key, Double.parseDouble(raw));
+          } catch (NumberFormatException nfe2) {
+            out.put(key, raw);
+          }
+        }
+      }
+    }
+    return out;
+  }
+}

--- a/benchmarks/src/main/java/com/tcn/exile/bench/LatencyHistogram.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/LatencyHistogram.java
@@ -1,0 +1,75 @@
+package com.tcn.exile.bench;
+
+import java.util.Arrays;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Simple, thread-safe sliding/bounded histogram that records long nanosecond samples and computes
+ * percentiles. Writers are serialized via a lock; reads make a snapshot and sort — cost is O(n log
+ * n) per read but this is only called at end-of-scenario.
+ */
+final class LatencyHistogram {
+  private final long[] data;
+  private int idx;
+  private int size;
+  private final ReentrantLock lock = new ReentrantLock();
+  private long totalCount;
+
+  LatencyHistogram(int capacity) {
+    this.data = new long[capacity];
+  }
+
+  void record(long nanos) {
+    lock.lock();
+    try {
+      data[idx] = nanos;
+      idx = (idx + 1) % data.length;
+      if (size < data.length) size++;
+      totalCount++;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  long count() {
+    lock.lock();
+    try {
+      return totalCount;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Returns [p50, p95, p99, max] in nanoseconds. Zero if empty. */
+  long[] percentiles() {
+    lock.lock();
+    long[] copy;
+    int n;
+    try {
+      n = size;
+      copy = Arrays.copyOf(data, n);
+    } finally {
+      lock.unlock();
+    }
+    if (n == 0) return new long[] {0, 0, 0, 0};
+    Arrays.sort(copy);
+    return new long[] {
+      copy[Math.max(0, n / 2 - 1)],
+      copy[Math.max(0, (int) Math.ceil(n * 0.95) - 1)],
+      copy[Math.max(0, (int) Math.ceil(n * 0.99) - 1)],
+      copy[n - 1]
+    };
+  }
+
+  void reset() {
+    lock.lock();
+    try {
+      idx = 0;
+      size = 0;
+      totalCount = 0;
+      Arrays.fill(data, 0L);
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/tcn/exile/bench/Main.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/Main.java
@@ -1,0 +1,214 @@
+package com.tcn.exile.bench;
+
+import com.tcn.exile.ExileClient;
+import com.tcn.exile.ExileConfig;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Benchmark runner entry point.
+ *
+ * <p>Usage:
+ *
+ * <pre>
+ *   ./gradlew :benchmarks:run --args="\
+ *     --certs=/tmp/sati-benchmark/certs \
+ *     --grpc-host=localhost --grpc-port=50051 \
+ *     --control-url=http://localhost:50052 \
+ *     --duration=60 \
+ *     --reports=/path/to/output \
+ *     [--scenario=burst-events-10k]        (default: run all)
+ *     [--max-concurrency=5]                (sati default)
+ *     [--job-latency-ms=10]                (plugin base latency per job)
+ *     [--event-latency-ms=5]               (plugin base latency per event)
+ *     [--plugin-error-rate=0.0]            (0..1, probability of throw per item)
+ * </pre>
+ */
+public final class Main {
+  private static final Logger log = LoggerFactory.getLogger(Main.class);
+
+  public static void main(String[] args) throws Exception {
+    Args a = Args.parse(args);
+
+    // Build plugin, config, client.
+    BenchmarkPlugin plugin =
+        new BenchmarkPlugin(
+            a.jobLatencyMs * 1_000_000L,
+            a.jobJitterMs * 1_000_000L,
+            a.eventLatencyMs * 1_000_000L,
+            a.eventJitterMs * 1_000_000L,
+            a.pluginErrorRate);
+
+    ExileConfig config =
+        ExileConfig.builder()
+            .rootCert(Files.readString(a.certsDir.resolve("ca.crt")))
+            .publicCert(Files.readString(a.certsDir.resolve("client.crt")))
+            .privateKey(Files.readString(a.certsDir.resolve("client.key")))
+            .apiHostname(a.grpcHost)
+            .apiPort(a.grpcPort)
+            .certificateName("bench-client")
+            .build();
+
+    ControlClient control = new ControlClient(a.controlUrl);
+    if (!control.waitHealthy(Duration.ofSeconds(30))) {
+      throw new IllegalStateException("control server not healthy at " + a.controlUrl);
+    }
+
+    log.info("Connecting to gate at {}:{}", a.grpcHost, a.grpcPort);
+    ExileClient client =
+        ExileClient.builder()
+            .config(config)
+            .plugin(plugin)
+            .clientName("sati-benchmark")
+            .clientVersion("0.0.0")
+            .maxConcurrency(a.maxConcurrency)
+            .build();
+
+    Report report = new Report();
+    report.putMetadata("timestamp", Instant.now().toString());
+    report.putMetadata("grpc_host", a.grpcHost + ":" + a.grpcPort);
+    report.putMetadata("max_concurrency", a.maxConcurrency);
+    report.putMetadata("duration_s", a.durationSeconds);
+    report.putMetadata("job_latency_ms", a.jobLatencyMs);
+    report.putMetadata("event_latency_ms", a.eventLatencyMs);
+    report.putMetadata("plugin_error_rate", a.pluginErrorRate);
+
+    try {
+      client.start();
+      // Wait for config poll + WorkStream to reach ACTIVE (client polls every 10 s; warm up 12 s).
+      log.info("Warming up (waiting for WorkStream to become ACTIVE)...");
+      long warmDeadline = System.nanoTime() + Duration.ofSeconds(20).toNanos();
+      while (System.nanoTime() < warmDeadline) {
+        var status = client.streamStatus();
+        if (status != null && status.phase() != null && status.phase().name().equals("ACTIVE")) {
+          log.info(
+              "WorkStream ACTIVE after {} ms",
+              (System.nanoTime() - (warmDeadline - Duration.ofSeconds(20).toNanos())) / 1_000_000);
+          break;
+        }
+        Thread.sleep(200);
+      }
+
+      List<String> toRun = a.scenario.equals("all") ? Scenarios.names() : List.of(a.scenario);
+      for (String name : toRun) {
+        Scenarios.Scenario s = Scenarios.ALL.get(name);
+        if (s == null) {
+          log.warn("Unknown scenario '{}' — skipping", name);
+          continue;
+        }
+        log.info("=== scenario: {} ===", name);
+        plugin.jobLatency.reset();
+        plugin.eventLatency.reset();
+        Report.Scenario rs = report.scenario(name);
+        long startNs = System.nanoTime();
+        s.run(
+            new Scenarios.Context(
+                plugin, client, control, Duration.ofSeconds(a.durationSeconds), rs));
+        long elapsedNs = System.nanoTime() - startNs;
+        finalizeScenario(rs, plugin, control, elapsedNs);
+        log.info(
+            "  jobs/s={}  events/s={}  job_p95={}ms  event_p95={}ms",
+            String.format(Locale.ROOT, "%.1f", rs.jobsPerSec),
+            String.format(Locale.ROOT, "%.1f", rs.eventsPerSec),
+            rs.jobLatencyMsP50P95P99Max[1],
+            rs.eventLatencyMsP50P95P99Max[1]);
+      }
+    } finally {
+      client.close();
+    }
+
+    // Write report.
+    String ts =
+        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+            .format(Instant.now().atZone(java.time.ZoneId.systemDefault()));
+    Path outPath = a.reportsDir.resolve(ts + ".json");
+    report.writeTo(outPath);
+    System.out.println();
+    System.out.println("=== report ===");
+    System.out.println(report.renderJson());
+    System.out.println("Written to: " + outPath);
+  }
+
+  private static void finalizeScenario(
+      Report.Scenario rs, BenchmarkPlugin plugin, ControlClient control, long elapsedNs) {
+    rs.durationSeconds = elapsedNs / 1_000_000_000.0;
+    rs.totalJobs = plugin.jobLatency.count();
+    rs.totalEvents = plugin.eventLatency.count();
+    rs.jobsPerSec = rs.totalJobs / Math.max(rs.durationSeconds, 1e-9);
+    rs.eventsPerSec = rs.totalEvents / Math.max(rs.durationSeconds, 1e-9);
+    rs.jobLatencyMsP50P95P99Max = nanosToMs(plugin.jobLatency.percentiles());
+    rs.eventLatencyMsP50P95P99Max = nanosToMs(plugin.eventLatency.percentiles());
+    try {
+      rs.serverStats = new LinkedHashMap<>(control.stats());
+    } catch (Exception e) {
+      log.warn("failed to fetch server stats: {}", e.getMessage());
+    }
+  }
+
+  private static long[] nanosToMs(long[] ns) {
+    long[] out = new long[ns.length];
+    for (int i = 0; i < ns.length; i++) out[i] = ns[i] / 1_000_000L;
+    return out;
+  }
+
+  static final class Args {
+    Path certsDir = Path.of("/tmp/sati-benchmark/certs");
+    String grpcHost = "localhost";
+    int grpcPort = 50051;
+    String controlUrl = "http://localhost:50052";
+    int durationSeconds = 60;
+    Path reportsDir = Path.of("./benchmarks/results");
+    String scenario = "all";
+    int maxConcurrency = 5;
+    long jobLatencyMs = 10;
+    long jobJitterMs = 5;
+    long eventLatencyMs = 5;
+    long eventJitterMs = 2;
+    double pluginErrorRate = 0.0;
+
+    static Args parse(String[] args) {
+      Args a = new Args();
+      List<String> errs = new ArrayList<>();
+      for (String arg : args) {
+        if (!arg.startsWith("--")) continue;
+        int eq = arg.indexOf('=');
+        if (eq < 0) continue;
+        String k = arg.substring(2, eq);
+        String v = arg.substring(eq + 1);
+        try {
+          switch (k) {
+            case "certs" -> a.certsDir = Path.of(v);
+            case "grpc-host" -> a.grpcHost = v;
+            case "grpc-port" -> a.grpcPort = Integer.parseInt(v);
+            case "control-url" -> a.controlUrl = v;
+            case "duration" -> a.durationSeconds = Integer.parseInt(v);
+            case "reports" -> a.reportsDir = Path.of(v);
+            case "scenario" -> a.scenario = v;
+            case "max-concurrency" -> a.maxConcurrency = Integer.parseInt(v);
+            case "job-latency-ms" -> a.jobLatencyMs = Long.parseLong(v);
+            case "job-jitter-ms" -> a.jobJitterMs = Long.parseLong(v);
+            case "event-latency-ms" -> a.eventLatencyMs = Long.parseLong(v);
+            case "event-jitter-ms" -> a.eventJitterMs = Long.parseLong(v);
+            case "plugin-error-rate" -> a.pluginErrorRate = Double.parseDouble(v);
+            default -> errs.add("unknown flag: " + k);
+          }
+        } catch (NumberFormatException nfe) {
+          errs.add("bad numeric value for --" + k + "=" + v);
+        }
+      }
+      if (!errs.isEmpty()) {
+        throw new IllegalArgumentException("bad args: " + String.join(", ", errs));
+      }
+      return a;
+    }
+  }
+}

--- a/benchmarks/src/main/java/com/tcn/exile/bench/Report.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/Report.java
@@ -1,0 +1,150 @@
+package com.tcn.exile.bench;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Minimal JSON report writer. Avoids pulling a JSON library for one use site.
+ *
+ * <p>Emits a single flat object per run; each scenario becomes a nested object.
+ */
+final class Report {
+  private final Map<String, Object> metadata = new LinkedHashMap<>();
+  private final Map<String, Scenario> scenarios = new LinkedHashMap<>();
+
+  void putMetadata(String key, Object value) {
+    metadata.put(key, value);
+  }
+
+  Scenario scenario(String name) {
+    return scenarios.computeIfAbsent(name, Scenario::new);
+  }
+
+  static final class Scenario {
+    final String name;
+    double durationSeconds;
+    double jobsPerSec;
+    double eventsPerSec;
+    long[] jobLatencyMsP50P95P99Max;
+    long[] eventLatencyMsP50P95P99Max;
+    long jobErrors;
+    long eventErrors;
+    long totalJobs;
+    long totalEvents;
+    Map<String, Object> serverStats;
+
+    Scenario(String name) {
+      this.name = name;
+    }
+  }
+
+  void writeTo(PrintStream out) {
+    out.print(renderJson());
+  }
+
+  void writeTo(Path path) throws IOException {
+    Files.createDirectories(path.getParent());
+    try (Writer w = Files.newBufferedWriter(path)) {
+      w.write(renderJson());
+    }
+  }
+
+  String renderJson() {
+    StringBuilder sb = new StringBuilder(1024);
+    sb.append("{\n");
+    sb.append("  \"metadata\": ");
+    writeMap(sb, metadata, 2);
+    sb.append(",\n  \"scenarios\": {\n");
+    boolean first = true;
+    for (var e : scenarios.entrySet()) {
+      if (!first) sb.append(",\n");
+      first = false;
+      writeScenario(sb, e.getKey(), e.getValue(), 4);
+    }
+    sb.append("\n  }\n}\n");
+    return sb.toString();
+  }
+
+  private void writeScenario(StringBuilder sb, String name, Scenario s, int indent) {
+    String pad = " ".repeat(indent);
+    sb.append(pad).append('"').append(esc(name)).append("\": {\n");
+    sb.append(pad).append("  \"duration_s\": ").append(fmt(s.durationSeconds)).append(",\n");
+    sb.append(pad).append("  \"throughput\": {");
+    sb.append("\"jobs_per_s\": ").append(fmt(s.jobsPerSec));
+    sb.append(", \"events_per_s\": ").append(fmt(s.eventsPerSec));
+    sb.append("},\n");
+    sb.append(pad).append("  \"total\": {");
+    sb.append("\"jobs\": ").append(s.totalJobs);
+    sb.append(", \"events\": ").append(s.totalEvents);
+    sb.append("},\n");
+    sb.append(pad).append("  \"errors\": {");
+    sb.append("\"jobs\": ").append(s.jobErrors);
+    sb.append(", \"events\": ").append(s.eventErrors);
+    sb.append("},\n");
+    sb.append(pad).append("  \"job_latency_ms\": ");
+    writePercentiles(sb, s.jobLatencyMsP50P95P99Max);
+    sb.append(",\n");
+    sb.append(pad).append("  \"event_latency_ms\": ");
+    writePercentiles(sb, s.eventLatencyMsP50P95P99Max);
+    if (s.serverStats != null) {
+      sb.append(",\n").append(pad).append("  \"server_stats\": ");
+      writeMap(sb, s.serverStats, indent + 2);
+    }
+    sb.append("\n").append(pad).append("}");
+  }
+
+  private void writePercentiles(StringBuilder sb, long[] p) {
+    if (p == null) p = new long[] {0, 0, 0, 0};
+    sb.append("{\"p50\": ").append(p[0]);
+    sb.append(", \"p95\": ").append(p[1]);
+    sb.append(", \"p99\": ").append(p[2]);
+    sb.append(", \"max\": ").append(p[3]);
+    sb.append("}");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void writeMap(StringBuilder sb, Map<String, Object> m, int indent) {
+    if (m.isEmpty()) {
+      sb.append("{}");
+      return;
+    }
+    String pad = " ".repeat(indent);
+    sb.append("{\n");
+    boolean first = true;
+    for (var e : m.entrySet()) {
+      if (!first) sb.append(",\n");
+      first = false;
+      sb.append(pad).append("  \"").append(esc(e.getKey())).append("\": ");
+      writeValue(sb, e.getValue(), indent + 2);
+    }
+    sb.append("\n").append(pad).append("}");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void writeValue(StringBuilder sb, Object v, int indent) {
+    if (v == null) {
+      sb.append("null");
+    } else if (v instanceof Number) {
+      sb.append(v);
+    } else if (v instanceof Boolean) {
+      sb.append(v);
+    } else if (v instanceof Map) {
+      writeMap(sb, (Map<String, Object>) v, indent);
+    } else {
+      sb.append('"').append(esc(v.toString())).append('"');
+    }
+  }
+
+  private static String esc(String s) {
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  private static String fmt(double d) {
+    return String.format("%.2f", d);
+  }
+}

--- a/benchmarks/src/main/java/com/tcn/exile/bench/Scenarios.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/Scenarios.java
@@ -1,0 +1,117 @@
+package com.tcn.exile.bench;
+
+import com.tcn.exile.ExileClient;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Scenario definitions — what load to drive during a benchmark run. */
+final class Scenarios {
+  private static final Logger log = LoggerFactory.getLogger(Scenarios.class);
+
+  static final Map<String, Scenario> ALL =
+      Map.of(
+          "burst-events-10k", Scenarios::burstEvents10k,
+          "sustained-jobs-100rps", Scenarios::sustainedJobs100rps,
+          "mixed-steady", Scenarios::mixedSteady,
+          "events-ramp-200rps", Scenarios::eventsRamp200rps);
+
+  static List<String> names() {
+    return ALL.keySet().stream().sorted().toList();
+  }
+
+  interface Scenario {
+    void run(Context ctx) throws Exception;
+  }
+
+  record Context(
+      BenchmarkPlugin plugin,
+      ExileClient client,
+      ControlClient control,
+      Duration duration,
+      Report.Scenario report) {}
+
+  // --- Scenarios ---
+
+  /**
+   * 10,000 events pushed at up to 1000 rps. Server must drain them through the event poller;
+   * measures event-throughput ceiling.
+   */
+  private static void burstEvents10k(Context ctx) throws Exception {
+    ctx.control.reset();
+    ctx.control.setEventRate(1000);
+    drive(ctx, () -> false); // run until duration elapses
+    ctx.control.setEventRate(0);
+  }
+
+  /** 100 jobs/sec sustained, no events. Measures job RTT and concurrency. */
+  private static void sustainedJobs100rps(Context ctx) throws Exception {
+    ctx.control.reset();
+    ctx.control.setEventRate(0);
+    drive(ctx, injectJobsAtRate(ctx.control, "list_pools", 100));
+  }
+
+  /** 100 jobs/sec + 500 events/sec. Measures priority fairness under mixed load. */
+  private static void mixedSteady(Context ctx) throws Exception {
+    ctx.control.reset();
+    ctx.control.setEventRate(500);
+    drive(ctx, injectJobsAtRate(ctx.control, "list_pools", 100));
+    ctx.control.setEventRate(0);
+  }
+
+  /**
+   * 200 events/s sustained. Pair with a higher plugin latency via {@code JOB_LATENCY_MS=200} /
+   * {@code EVENT_LATENCY_MS=200} to stress the concurrency cap: at maxConcurrency=5 with a 200
+   * ms-per-item plugin, steady-state throughput maxes at ~25 items/s.
+   */
+  private static void eventsRamp200rps(Context ctx) throws Exception {
+    ctx.control.reset();
+    ctx.control.setEventRate(200);
+    drive(ctx, () -> false);
+    ctx.control.setEventRate(0);
+  }
+
+  // --- Helpers ---
+
+  /**
+   * Runs a load-driver step at ~10 Hz for the duration, recording when to stop. The step returns
+   * true to signal it's done early (e.g., finite job injection); returning false means keep running
+   * until duration elapses.
+   */
+  private static void drive(Context ctx, StepFn step) throws Exception {
+    long startMs = System.currentTimeMillis();
+    long endMs = startMs + ctx.duration.toMillis();
+    AtomicBoolean stop = new AtomicBoolean(false);
+    while (!stop.get() && System.currentTimeMillis() < endMs) {
+      try {
+        if (step.step()) stop.set(true);
+      } catch (Exception e) {
+        log.warn("drive step failed: {}", e.getMessage());
+      }
+      TimeUnit.MILLISECONDS.sleep(100);
+    }
+  }
+
+  @FunctionalInterface
+  private interface StepFn {
+    /** Returns true to stop early. */
+    boolean step() throws Exception;
+  }
+
+  /** Step function that injects {@code rps/10} jobs every 100 ms. */
+  private static StepFn injectJobsAtRate(ControlClient control, String type, int rps) {
+    int perTick = Math.max(1, rps / 10);
+    return () -> {
+      try {
+        control.injectJobs(type, perTick);
+      } catch (Exception e) {
+        log.warn("inject failed: {}", e.getMessage());
+      }
+      return false;
+    };
+  }
+}

--- a/benchmarks/src/main/resources/logback.xml
+++ b/benchmarks/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} %-5level %logger{32} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<!-- Silence gRPC netty frame-level logs that flood stdout. -->
+	<logger name="io.grpc.netty.shaded" level="INFO"/>
+	<logger name="io.grpc" level="INFO"/>
+
+	<!-- sati client internals stay at INFO; per-item result-accepted debug is noisy. -->
+	<logger name="com.tcn.exile.internal.WorkStreamClient" level="INFO"/>
+
+	<root level="INFO">
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name="sati"
 
-include('core', 'config', 'logback-ext', 'demo')
+include('core', 'config', 'logback-ext', 'demo', 'benchmarks')


### PR DESCRIPTION
## Summary

Adds a `:benchmarks` Gradle subproject that drives end-to-end load through the real `ExileClient` against a standalone Go server simulator (lives in `exile/exile/gatev3-benchmark-server` — see companion MR https://git.tcncloud.net/exile/exile/-/merge_requests/210). Establishes a baseline before the WorkStream v3 adaptive-concurrency work and will measure each S/C change as it lands.

## What's in the subproject

- **`BenchmarkPlugin`** — configurable per-method latency (ms base + jitter) + error rate, implemented on top of `PluginBase`. Handlers record observed latency into thread-safe `LatencyHistogram`s, one per category (jobs vs events).
- **`LatencyHistogram`** — bounded ring buffer with p50/p95/p99/max accessors.
- **`ControlClient`** — HTTP client for the Go server's `/health`, `/reset`, `/set-event-rate`, `/inject-job`, `/stats` endpoints. Includes a naive single-purpose JSON parser so we don't pull Jackson for one call site.
- **`Scenarios`** — four named load profiles:
  - `burst-events-10k` — 1000 event/s from the server generator; tests event throughput ceiling.
  - `sustained-jobs-100rps` — 100 job/s via `/inject-job`; tests job RTT + concurrency.
  - `mixed-steady` — 100 jobs/s + 500 events/s; tests priority fairness.
  - `events-ramp-200rps` — 200 events/s; pair with `EVENT_LATENCY_MS=200` to stress concurrency cap.
- **`Report`** — JSON writer, no deps. One object per scenario with throughput, percentiles, error counts, and server-side counter snapshot.
- **`Main`** — CLI entry point that builds `ExileClient`, runs scenarios, writes a timestamped JSON report.
- **`logback.xml`** — silences gRPC netty frame-level debug logs.

## Running it

`make benchmark` at repo root. Java is provisioned via SDKMAN using the repo's `.sdkmanrc` (currently `21.0.9-amzn`) — works with macOS stock GNU Make 3.81. Requires a local `exile/exile` clone (default path `../../tcn/exile/exile`; override with `EXILE_REPO=...`).

```bash
make benchmark                               # all scenarios, 60s each
make benchmark SCENARIO=mixed-steady         # one scenario
make benchmark DURATION=30                   # shorter run
make benchmark MAX_CONCURRENCY=50            # what throughput looks like with more
make benchmark EVENT_LATENCY_MS=200          # stress concurrency cap
```

Reports land in `benchmarks/results/<timestamp>.json` and are also printed to stdout.

## Example output (smoke-tested)

```json
"mixed-steady": {
  "duration_s": 6.04,
  "throughput": {"jobs_per_s": 94.42, "events_per_s": 488.65},
  "total":      {"jobs": 570, "events": 2950},
  "errors":     {"jobs": 0, "events": 0},
  "job_latency_ms":   {"p50": 10, "p95": 14, "p99": 15, "max": 15},
  "event_latency_ms": {"p50": 5,  "p95": 6,  "p99": 7,  "max": 10},
  "server_stats": { ... }
}
```

## Dependencies

- `:core` (real `ExileClient`, `ExileConfig`, `Plugin`)
- `io.grpc:grpc-netty-shaded` (already used transitively)
- `ch.qos.logback:logback-classic` for the `logback.xml` config

Publishing is explicitly disabled for this subproject — not a consumable artifact.

## Test plan

- [x] `./gradlew :benchmarks:compileJava` passes.
- [x] `./gradlew :benchmarks:spotlessApply` clean.
- [x] End-to-end smoke: 6s `mixed-steady` run shows 94 jobs/s + 489 events/s with expected p95 latencies.
- [x] Full 60s baseline run for all four scenarios — captured after merge.
- [ ] Re-run after each of C1–C4 lands to verify client-side gains.

## Related

- Epic: https://git.tcncloud.net/groups/exile/-/epics/9
- Companion MR on exile/exile (Go server): https://git.tcncloud.net/exile/exile/-/merge_requests/210
- Paves the way for client-side issues #43 (C1), #44 (C2), #45 (C3), #46 (C4).
