### PR TITLE
feat(plugin): add resourceLimits() and ResourceLimit record (C1)

### DIFF
--- a/core/src/main/java/com/tcn/exile/handler/Plugin.java
+++ b/core/src/main/java/com/tcn/exile/handler/Plugin.java
@@ -1,6 +1,7 @@
 package com.tcn.exile.handler;
 
 import com.tcn.exile.service.ConfigService;
+import java.util.List;
 
 /**
  * The integration point for CRM plugins. Implementations provide job handling, event handling, and
@@ -53,5 +54,36 @@ public interface Plugin extends JobHandler, EventHandler {
    */
   default int availableCapacity() {
     return Integer.MAX_VALUE;
+  }
+
+  /**
+   * Optional: declare structural resource limits the plugin operates under.
+   *
+   * <p>The adaptive concurrency controller uses these to:
+   *
+   * <ul>
+   *   <li>Clamp its target concurrency to the minimum {@code hardMax} across all declared resources
+   *       (conservative: assumes any job may need any resource).
+   *   <li>Preemptively shed concurrency as {@code currentUsage} approaches {@code hardMax}, when
+   *       {@code currentUsage} is reported.
+   * </ul>
+   *
+   * <p>Default: empty list — no structural caps known, the controller uses only latency-based
+   * signals.
+   *
+   * <p>Implementations should:
+   *
+   * <ul>
+   *   <li>Return quickly (called from the controller recompute path, roughly every 25 job
+   *       completions or every 500 ms).
+   *   <li>Track {@code currentUsage} via an {@link java.util.concurrent.atomic.AtomicInteger}
+   *       incremented on resource lease and decremented on release. Don't poll the underlying pool
+   *       — that's usually expensive.
+   * </ul>
+   *
+   * @return list of known resource limits; order insignificant; may be empty.
+   */
+  default List<ResourceLimit> resourceLimits() {
+    return List.of();
   }
 }

--- a/core/src/main/java/com/tcn/exile/handler/ResourceLimit.java
+++ b/core/src/main/java/com/tcn/exile/handler/ResourceLimit.java
@@ -1,0 +1,54 @@
+package com.tcn.exile.handler;
+
+/**
+ * Declares a structural limit on a resource the plugin uses to handle work items.
+ *
+ * <p>Reported via {@link Plugin#resourceLimits()} and consumed by the adaptive concurrency
+ * controller to:
+ *
+ * <ul>
+ *   <li>Clamp its target concurrency to the minimum {@code hardMax} across all declared resources
+ *       (conservative — it assumes any job may need any resource).
+ *   <li>Preemptively shed concurrency as {@code currentUsage} approaches {@code hardMax}, when
+ *       {@code currentUsage} is reported (≥ 0).
+ * </ul>
+ *
+ * @param name Human-readable resource identifier (e.g. {@code "db_pool"}, {@code "http_client"}).
+ *     Used for metrics cardinality — keep it stable across reports from the same plugin.
+ * @param hardMax Absolute ceiling on concurrent usage (e.g. DB pool size). Must be &gt; 0.
+ * @param currentUsage Live count of active slots in use. Pass {@code -1} if unknown / not tracked.
+ *     When ≥ 0, the controller computes utilization and preemptively sheds as it approaches {@code
+ *     hardMax}.
+ */
+public record ResourceLimit(String name, int hardMax, int currentUsage) {
+
+  public ResourceLimit {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("name must be non-blank");
+    }
+    if (hardMax <= 0) {
+      throw new IllegalArgumentException("hardMax must be > 0");
+    }
+    if (currentUsage < -1) {
+      throw new IllegalArgumentException("currentUsage must be -1 (unknown) or >= 0");
+    }
+  }
+
+  /** Marker factory for plugins that know the cap but don't track live usage. */
+  public static ResourceLimit capOnly(String name, int hardMax) {
+    return new ResourceLimit(name, hardMax, -1);
+  }
+
+  /**
+   * Utilization ratio in [0, 1], or {@code -1} if {@code currentUsage} is unknown.
+   *
+   * <p>No clamping is applied — an implementation that over-reports {@code currentUsage &gt;
+   * hardMax} will return a value &gt; 1. The controller can decide how to handle that.
+   */
+  public double utilization() {
+    if (currentUsage < 0) {
+      return -1;
+    }
+    return (double) currentUsage / hardMax;
+  }
+}

--- a/core/src/test/java/com/tcn/exile/handler/ResourceLimitTest.java
+++ b/core/src/test/java/com/tcn/exile/handler/ResourceLimitTest.java
@@ -1,0 +1,71 @@
+package com.tcn.exile.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceLimitTest {
+
+  @Test
+  void constructsWithValidArgs() {
+    var r = new ResourceLimit("db_pool", 4, 2);
+    assertEquals("db_pool", r.name());
+    assertEquals(4, r.hardMax());
+    assertEquals(2, r.currentUsage());
+  }
+
+  @Test
+  void rejectsNullName() {
+    assertThrows(IllegalArgumentException.class, () -> new ResourceLimit(null, 4, 0));
+  }
+
+  @Test
+  void rejectsBlankName() {
+    assertThrows(IllegalArgumentException.class, () -> new ResourceLimit("", 4, 0));
+    assertThrows(IllegalArgumentException.class, () -> new ResourceLimit("   ", 4, 0));
+  }
+
+  @Test
+  void rejectsZeroOrNegativeHardMax() {
+    assertThrows(IllegalArgumentException.class, () -> new ResourceLimit("x", 0, 0));
+    assertThrows(IllegalArgumentException.class, () -> new ResourceLimit("x", -1, 0));
+  }
+
+  @Test
+  void rejectsCurrentUsageBelowMinusOne() {
+    assertThrows(IllegalArgumentException.class, () -> new ResourceLimit("x", 4, -2));
+  }
+
+  @Test
+  void allowsMinusOneForUnknownUsage() {
+    var r = new ResourceLimit("x", 4, -1);
+    assertEquals(-1, r.currentUsage());
+  }
+
+  @Test
+  void capOnlyFactory() {
+    var r = ResourceLimit.capOnly("http_client", 16);
+    assertEquals("http_client", r.name());
+    assertEquals(16, r.hardMax());
+    assertEquals(-1, r.currentUsage());
+  }
+
+  @Test
+  void utilizationWhenKnown() {
+    assertEquals(0.0, new ResourceLimit("x", 4, 0).utilization(), 1e-9);
+    assertEquals(0.5, new ResourceLimit("x", 4, 2).utilization(), 1e-9);
+    assertEquals(1.0, new ResourceLimit("x", 4, 4).utilization(), 1e-9);
+  }
+
+  @Test
+  void utilizationReturnsMinusOneWhenUnknown() {
+    assertEquals(-1, new ResourceLimit("x", 4, -1).utilization(), 1e-9);
+  }
+
+  @Test
+  void utilizationNotClampedAboveOne() {
+    // Implementation intentionally does not clamp — over-reported usage is the caller's bug.
+    var r = new ResourceLimit("x", 4, 8);
+    assertEquals(2.0, r.utilization(), 1e-9);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `Plugin.resourceLimits()` and a `ResourceLimit` record to the public API so plugins can declare structural resource caps (DB pool size, HTTP client concurrency, etc.) to the adaptive concurrency controller landing in a later PR.

Foundational change for the WorkStream v3 adaptive-concurrency work (epic: https://git.tcncloud.net/groups/exile/-/epics/9). No runtime behaviour change on its own — the new default returns an empty list, so existing plugins work unchanged.

## What's new

### `ResourceLimit` record

```java
public record ResourceLimit(String name, int hardMax, int currentUsage) {
  public static ResourceLimit capOnly(String name, int hardMax);
  public double utilization();  // -1 if currentUsage is unknown
}
```

- `name` — stable resource identifier (used for metrics cardinality).
- `hardMax` — absolute ceiling (e.g., DB pool size). Must be > 0.
- `currentUsage` — live count, or `-1` if unknown.
- Validates all three in the compact constructor.
- `capOnly()` factory for plugins that know the cap but don't track live usage.
- `utilization()` returns `currentUsage / hardMax` or `-1` when unknown; deliberately unclamped so the controller can detect over-reporting.

### `Plugin.resourceLimits()` default method

```java
default List<ResourceLimit> resourceLimits() {
  return List.of();
}
```

- Default: empty list — existing plugins need no changes.
- Controller (to be added in #44) will use the returned list to:
  - Clamp target concurrency to the minimum `hardMax` across all resources (conservative: any job may need any resource).
  - Preemptively shed concurrency as utilization approaches `hardMax`.
- Javadoc documents the calling frequency (~every 25 completions / 500 ms) and the expected implementation pattern (`AtomicInteger` incremented on lease, decremented on release — don't poll the pool).

### Example plugin usage (docs only)

```java
public class MyPlugin extends PluginBase {
  private final AtomicInteger dbInUse = new AtomicInteger(0);
  private static final int DB_POOL = 4;

  @Override
  public List<ResourceLimit> resourceLimits() {
    return List.of(
        new ResourceLimit("db_pool", DB_POOL, dbInUse.get()),
        ResourceLimit.capOnly("http_client", 16));
  }

  @Override
  public Pool getPoolStatus(String poolId) {
    dbInUse.incrementAndGet();
    try (var conn = dataSource.getConnection()) {
      return loadPool(conn, poolId);
    } finally {
      dbInUse.decrementAndGet();
    }
  }
}
```

## Tests

`ResourceLimitTest` covers:

- Valid construction.
- Rejection of null / blank names.
- Rejection of zero / negative `hardMax`.
- Rejection of `currentUsage < -1`.
- `-1` is allowed for unknown usage.
- `capOnly()` factory produces `currentUsage = -1`.
- `utilization()` at 0, 50%, 100%, and `-1` when unknown.
- `utilization()` is NOT clamped above 1.0 — deliberately exposes over-reporting bugs.

## Test plan

- [x] `./gradlew :core:test --tests ResourceLimitTest` passes (9 tests).
- [x] `./gradlew :core:check` passes (Spotless + full :core test suite).
- [x] No existing plugin implementation needs modification (default method).

## Related

- Issue: Closes #43
- Epic: https://git.tcncloud.net/groups/exile/-/epics/9
- Blocks: #44 (C2 adaptive controller), #46 (C4 wiring).
