### PR TITLE
feat(client): expose AdaptiveSnapshot API for plugin diagnostics (follow-up to C4)

### DIFF
--- a/benchmarks/src/main/java/com/tcn/exile/bench/Main.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/Main.java
@@ -121,6 +121,34 @@ public final class Main {
             String.format(Locale.ROOT, "%.1f", rs.eventsPerSec),
             rs.jobLatencyMsP50P95P99Max[1],
             rs.eventLatencyMsP50P95P99Max[1]);
+        client
+            .adaptiveSnapshot()
+            .ifPresent(
+                snap -> {
+                  log.info(
+                      "  adaptive: limit={} ceiling={} p95={}ms ema={}ms min={}ms"
+                          + "  sloG={} minG={} resG={} errors={}",
+                      snap.limit(),
+                      snap.effectiveCeiling(),
+                      snap.jobP95Millis(),
+                      snap.jobEmaMillis(),
+                      snap.decayingMinMillis(),
+                      String.format(Locale.ROOT, "%.2f", snap.sloGradient()),
+                      String.format(Locale.ROOT, "%.2f", snap.minGradient()),
+                      String.format(Locale.ROOT, "%.2f", snap.resourceGradient()),
+                      snap.errorCount());
+                  rs.adaptive =
+                      java.util.Map.of(
+                          "limit", (Object) snap.limit(),
+                          "effective_ceiling", (Object) snap.effectiveCeiling(),
+                          "job_p95_ms", (Object) snap.jobP95Millis(),
+                          "job_ema_ms", (Object) snap.jobEmaMillis(),
+                          "decaying_min_ms", (Object) snap.decayingMinMillis(),
+                          "slo_gradient", (Object) snap.sloGradient(),
+                          "min_gradient", (Object) snap.minGradient(),
+                          "resource_gradient", (Object) snap.resourceGradient(),
+                          "errors", (Object) snap.errorCount());
+                });
       }
     } finally {
       client.close();

--- a/benchmarks/src/main/java/com/tcn/exile/bench/Report.java
+++ b/benchmarks/src/main/java/com/tcn/exile/bench/Report.java
@@ -37,6 +37,7 @@ final class Report {
     long totalJobs;
     long totalEvents;
     Map<String, Object> serverStats;
+    Map<String, Object> adaptive;
 
     Scenario(String name) {
       this.name = name;
@@ -94,6 +95,10 @@ final class Report {
     if (s.serverStats != null) {
       sb.append(",\n").append(pad).append("  \"server_stats\": ");
       writeMap(sb, s.serverStats, indent + 2);
+    }
+    if (s.adaptive != null) {
+      sb.append(",\n").append(pad).append("  \"adaptive\": ");
+      writeMap(sb, s.adaptive, indent + 2);
     }
     sb.append("\n").append(pad).append("}");
   }

--- a/core/src/main/java/com/tcn/exile/AdaptiveSnapshot.java
+++ b/core/src/main/java/com/tcn/exile/AdaptiveSnapshot.java
@@ -1,0 +1,61 @@
+package com.tcn.exile;
+
+/**
+ * Read-only snapshot of the adaptive concurrency controller's state at a point in time.
+ *
+ * <p>Obtained via {@link ExileClient#adaptiveSnapshot()}. Intended for plugin diagnostics,
+ * dashboards, and custom metrics export. Reading a snapshot is cheap (no locks, no allocation
+ * beyond the record itself).
+ *
+ * <p>Latency fields are exposed in nanoseconds (the controller's native unit) with millisecond
+ * convenience accessors layered on top.
+ *
+ * @param limit Current target in-flight work count. The WorkStream uses this to cap how many
+ *     credits it will grant the server at a time.
+ * @param minLimit Configured safety floor. The controller won't shed below this value.
+ * @param maxLimit Configured safety ceiling. The controller won't grow above this value.
+ * @param effectiveCeiling {@code min(maxLimit, min over plugin resourceLimits().hardMax)} — the
+ *     true upper bound the controller targets, after plugin-declared structural caps.
+ * @param jobP95Nanos Sliding-window p95 of job completion latency (nanos). Zero before any sample.
+ * @param jobEmaNanos Exponentially-weighted moving average of job latency (nanos).
+ * @param decayingMinNanos Controller's decaying minimum — the fastest observation recently seen,
+ *     drifting upward slowly to avoid one lucky sample pinning the floor forever.
+ * @param sloGradient Last computed SLO gradient: {@code clamp(SLO_NANOS / jobP95Nanos, 0.5..1.0)}.
+ *     Values below 1.0 mean p95 is approaching the 500 ms job SLO.
+ * @param minGradient Last computed min gradient: {@code clamp(decayingMinNanos / jobEmaNanos,
+ *     0.5..1.0)}. Values below 1.0 indicate queueing buildup somewhere downstream.
+ * @param resourceGradient Last computed resource gradient: min across plugin-declared resources
+ *     that report {@code currentUsage}. Values below 1.0 indicate a resource approaching saturation
+ *     (sheds starting at 70% utilization).
+ * @param errorCount Cumulative plugin errors observed by the controller since construction.
+ * @param sampleCount Number of successful job-completion samples fed to the controller.
+ */
+public record AdaptiveSnapshot(
+    int limit,
+    int minLimit,
+    int maxLimit,
+    int effectiveCeiling,
+    long jobP95Nanos,
+    long jobEmaNanos,
+    long decayingMinNanos,
+    double sloGradient,
+    double minGradient,
+    double resourceGradient,
+    int errorCount,
+    int sampleCount) {
+
+  /** p95 latency in milliseconds (rounded down). */
+  public long jobP95Millis() {
+    return jobP95Nanos / 1_000_000L;
+  }
+
+  /** EMA latency in milliseconds (rounded down). */
+  public long jobEmaMillis() {
+    return jobEmaNanos / 1_000_000L;
+  }
+
+  /** Decaying min latency in milliseconds (rounded down). */
+  public long decayingMinMillis() {
+    return decayingMinNanos / 1_000_000L;
+  }
+}

--- a/core/src/main/java/com/tcn/exile/ExileClient.java
+++ b/core/src/main/java/com/tcn/exile/ExileClient.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -212,6 +213,35 @@ public final class ExileClient implements AutoCloseable {
 
   public StreamStatus streamStatus() {
     return workStream.status();
+  }
+
+  /**
+   * Snapshot of the adaptive concurrency controller's current state, for plugin diagnostics,
+   * dashboards, and custom metric export. Returns empty when adaptive is disabled — either the
+   * caller passed an explicit {@link Builder#capacityProvider} or called {@code adaptive(false)}.
+   *
+   * <p>Polling this is cheap: all reads are from {@code volatile} fields or {@code AtomicLong}s.
+   * Safe to call from any thread, including plugin handler virtual threads.
+   */
+  public Optional<AdaptiveSnapshot> adaptiveSnapshot() {
+    var a = adaptive;
+    if (a == null) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new AdaptiveSnapshot(
+            a.limit(),
+            a.minLimit(),
+            a.maxLimit(),
+            a.effectiveCeiling(),
+            a.jobP95Nanos(),
+            a.jobEmaNanos(),
+            a.decayingMinNanos(),
+            a.lastSloGradient(),
+            a.lastMinGradient(),
+            a.lastResourceGradient(),
+            a.errorCount(),
+            a.sampleCount()));
   }
 
   public ExileConfig config() {

--- a/core/src/test/java/com/tcn/exile/AdaptiveSnapshotTest.java
+++ b/core/src/test/java/com/tcn/exile/AdaptiveSnapshotTest.java
@@ -1,0 +1,27 @@
+package com.tcn.exile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class AdaptiveSnapshotTest {
+
+  @Test
+  void millisAccessorsRoundDownFromNanos() {
+    var s =
+        new AdaptiveSnapshot(
+            10, 1, 100, 100, 1_500_000L, 2_900_000L, 999_999L, 1.0, 1.0, 1.0, 0, 0);
+    assertEquals(1, s.jobP95Millis());
+    assertEquals(2, s.jobEmaMillis());
+    assertEquals(0, s.decayingMinMillis(), "sub-millisecond truncates to 0");
+  }
+
+  @Test
+  void emptyStateIsWellFormed() {
+    var s = new AdaptiveSnapshot(1, 1, 100, 100, 0L, 0L, 0L, 1.0, 1.0, 1.0, 0, 0);
+    assertEquals(0, s.jobP95Millis());
+    assertEquals(0, s.jobEmaMillis());
+    assertEquals(0, s.decayingMinMillis());
+    assertEquals(1.0, s.sloGradient(), 1e-9);
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #52 (merged into v3.1.0) — exposes a stable public read-only API so plugins can read the adaptive controller's state for diagnostics, dashboards, and custom metrics export.

This commit was originally part of the C4 branch but landed after #52 was merged, so it didn't make it into the v3.1.0 release.

## What's new

- **`AdaptiveSnapshot`** (new public record in `com.tcn.exile`) — all gauge values in one immutable snapshot:
  - `limit`, `minLimit`, `maxLimit`, `effectiveCeiling`
  - `jobP95Nanos`, `jobEmaNanos`, `decayingMinNanos` (+ `*Millis()` convenience accessors)
  - `sloGradient`, `minGradient`, `resourceGradient`
  - `errorCount`, `sampleCount`

- **`ExileClient.adaptiveSnapshot()`** → `Optional<AdaptiveSnapshot>` — empty when the caller disabled adaptive (explicit `capacityProvider(...)` or `adaptive(false)`).

Reads are cheap (`volatile` and `AtomicLong` access, no locks), safe from any thread, and allocate only the record itself.

## Example plugin usage

```java
exile.adaptiveSnapshot().ifPresent(snap -> {
    dashboard.put("adaptive.limit", snap.limit());
    dashboard.put("adaptive.job_p95_ms", snap.jobP95Millis());
    dashboard.put("adaptive.slo_gradient", snap.sloGradient());
    if (snap.sloGradient() < 0.9) {
        // controller is shedding; plugin could trim its own queue
    }
});
```

## Benchmark harness update

Same commit also surfaces the snapshot in the `benchmarks/` runner — logs it after each scenario and embeds it in the JSON report:

```
14:20:17 INFO Main - === scenario: mixed-steady ===
14:20:17 INFO Main -   jobs/s=96.2  events/s=498.2  job_p95=104ms  event_p95=53ms
14:20:17 INFO Main -   adaptive: limit=10 ceiling=100 p95=104ms ema=100ms min=97ms
                         sloG=1.00 minG=0.98 resG=1.00 errors=0
```

## Test plan

- [x] `./gradlew :core:check` — 2 new tests pass (111 total).
- [x] Spotless clean.
- [x] Backwards-compatible — no changes to existing public APIs.

## Ship

Intended to go out as **v3.1.1**. `finvi` is blocked on this — its adaptive-metrics dashboard panel imports `com.tcn.exile.AdaptiveSnapshot` which doesn't exist in v3.1.0.

## Related

- Follow-up to: #52 (C4 wire adaptive, merged)
- Epic: https://git.tcncloud.net/groups/exile/-/epics/9
