### PR TITLE
feat(client): drain in-flight work on close, preserve Results/Acks

### DIFF
--- a/core/src/main/java/com/tcn/exile/ExileClient.java
+++ b/core/src/main/java/com/tcn/exile/ExileClient.java
@@ -79,7 +79,8 @@ public final class ExileClient implements AutoCloseable {
             builder.clientName,
             builder.clientVersion,
             builder.maxConcurrency,
-            builder.capabilities);
+            builder.capabilities,
+            builder.shutdownDrainTimeout);
 
     this.serviceChannel = ChannelFactory.create(config);
     var services = ServiceFactory.create(serviceChannel);
@@ -354,6 +355,8 @@ public final class ExileClient implements AutoCloseable {
     private IntSupplier capacityProvider;
     private List<build.buf.gen.tcnapi.exile.gate.v3.WorkType> capabilities = new ArrayList<>();
     private Duration configPollInterval = Duration.ofSeconds(10);
+    private Duration shutdownDrainTimeout =
+        com.tcn.exile.internal.WorkStreamClient.DEFAULT_SHUTDOWN_DRAIN_TIMEOUT;
 
     private Builder() {}
 
@@ -428,6 +431,26 @@ public final class ExileClient implements AutoCloseable {
     /** How often to poll the gate for config updates. Default: 10 seconds. */
     public Builder configPollInterval(Duration interval) {
       this.configPollInterval = Objects.requireNonNull(interval);
+      return this;
+    }
+
+    /**
+     * Maximum time {@link ExileClient#close()} will wait for in-flight work items to finish before
+     * forcing shutdown. During this window:
+     *
+     * <ul>
+     *   <li>No new {@code Pull} messages are sent, so the gate stops dispatching work.
+     *   <li>Plugin handlers that were already running complete normally and their Result/Ack
+     *       messages flow back to the gate.
+     *   <li>If the timeout elapses the worker pool is forcibly shut down; unfinished items will be
+     *       re-delivered by the gate after server-side lease expiry.
+     * </ul>
+     *
+     * <p>Default: 30 seconds. Setting {@link Duration#ZERO} disables the drain (legacy behaviour —
+     * in-flight handlers run but their results may be lost).
+     */
+    public Builder shutdownDrainTimeout(Duration timeout) {
+      this.shutdownDrainTimeout = Objects.requireNonNull(timeout);
       return this;
     }
 

--- a/core/src/main/java/com/tcn/exile/StreamStatus.java
+++ b/core/src/main/java/com/tcn/exile/StreamStatus.java
@@ -39,7 +39,14 @@ public record StreamStatus(
     /** Stream disconnected, waiting to reconnect (backoff). */
     RECONNECTING,
     /** Client has been closed. */
-    CLOSED
+    CLOSED,
+    /**
+     * Graceful shutdown in progress: no new Pulls are sent, in-flight work is allowed to complete,
+     * and Results/Acks still flow until either the worker pool drains or the drain timeout elapses.
+     * Appended here (ordinal 6) to preserve existing ordinal values for dashboard consumers relying
+     * on the numeric `exile.work.phase` metric.
+     */
+    DRAINING
   }
 
   /** True if the stream is connected and processing work. */

--- a/core/src/main/java/com/tcn/exile/internal/MetricsManager.java
+++ b/core/src/main/java/com/tcn/exile/internal/MetricsManager.java
@@ -118,7 +118,8 @@ public final class MetricsManager implements AutoCloseable {
         .gaugeBuilder("exile.work.phase")
         .ofLongs()
         .setDescription(
-            "WorkStream phase (0=IDLE, 1=CONNECTING, 2=REGISTERING, 3=ACTIVE, 4=RECONNECTING, 5=CLOSED)")
+            "WorkStream phase (0=IDLE, 1=CONNECTING, 2=REGISTERING, 3=ACTIVE, 4=RECONNECTING,"
+                + " 5=CLOSED, 6=DRAINING)")
         .setUnit("1")
         .buildWithCallback(obs -> obs.record(statusSupplier.get().phase().ordinal()));
 

--- a/core/src/main/java/com/tcn/exile/internal/WorkStreamClient.java
+++ b/core/src/main/java/com/tcn/exile/internal/WorkStreamClient.java
@@ -47,6 +47,13 @@ public final class WorkStreamClient implements AutoCloseable {
 
   private static final Logger log = LoggerFactory.getLogger(WorkStreamClient.class);
 
+  /**
+   * Default bound on drain-on-close. Long enough for normal plugin latencies, short enough that a
+   * wedged plugin can't hold the JVM open indefinitely.
+   */
+  public static final java.time.Duration DEFAULT_SHUTDOWN_DRAIN_TIMEOUT =
+      java.time.Duration.ofSeconds(30);
+
   private final ExileConfig config;
   private final JobHandler jobHandler;
   private final EventHandler eventHandler;
@@ -55,8 +62,22 @@ public final class WorkStreamClient implements AutoCloseable {
   private final String clientVersion;
   private final int maxConcurrency;
   private final List<WorkType> capabilities;
+  private final java.time.Duration shutdownDrainTimeout;
 
   private final AtomicBoolean running = new AtomicBoolean(false);
+
+  /**
+   * Set to {@code true} on the first call to {@link #close()}. While draining:
+   *
+   * <ul>
+   *   <li>{@link #refillToTarget()} stops sending {@code Pull} — the server's dispatch stops.
+   *   <li>The request observer stays live so in-flight plugin handlers can send Result/Ack.
+   *   <li>The receive loop continues reading until the server's {@code onCompleted} closes it,
+   *       delivering any ResultAccepted/NackAccepted the server sends.
+   * </ul>
+   */
+  private final AtomicBoolean draining = new AtomicBoolean(false);
+
   private final AtomicReference<StreamObserver<WorkRequest>> requestObserver =
       new AtomicReference<>();
   private final AtomicReference<ClientCallStreamObserver<WorkRequest>> responseStream =
@@ -120,7 +141,8 @@ public final class WorkStreamClient implements AutoCloseable {
         clientName,
         clientVersion,
         maxConcurrency,
-        capabilities);
+        capabilities,
+        DEFAULT_SHUTDOWN_DRAIN_TIMEOUT);
   }
 
   /**
@@ -136,6 +158,32 @@ public final class WorkStreamClient implements AutoCloseable {
       String clientVersion,
       int maxConcurrency,
       List<WorkType> capabilities) {
+    this(
+        config,
+        jobHandler,
+        eventHandler,
+        capacityProvider,
+        clientName,
+        clientVersion,
+        maxConcurrency,
+        capabilities,
+        DEFAULT_SHUTDOWN_DRAIN_TIMEOUT);
+  }
+
+  /**
+   * Full constructor including the drain-on-close timeout. See {@link
+   * com.tcn.exile.ExileClient.Builder#shutdownDrainTimeout} for semantics.
+   */
+  public WorkStreamClient(
+      ExileConfig config,
+      JobHandler jobHandler,
+      EventHandler eventHandler,
+      IntSupplier capacityProvider,
+      String clientName,
+      String clientVersion,
+      int maxConcurrency,
+      List<WorkType> capabilities,
+      java.time.Duration shutdownDrainTimeout) {
     this.config = config;
     this.jobHandler = jobHandler;
     this.eventHandler = eventHandler;
@@ -144,6 +192,8 @@ public final class WorkStreamClient implements AutoCloseable {
     this.clientVersion = clientVersion;
     this.maxConcurrency = maxConcurrency;
     this.capabilities = capabilities;
+    this.shutdownDrainTimeout =
+        shutdownDrainTimeout != null ? shutdownDrainTimeout : DEFAULT_SHUTDOWN_DRAIN_TIMEOUT;
   }
 
   /** Returns a snapshot of the stream's current state. */
@@ -748,8 +798,15 @@ public final class WorkStreamClient implements AutoCloseable {
    * Refill gRPC credits and server Pulls up to the current capacity target. Called after each
    * work-item completion. If the controller has grown the target, this pulls the delta in one shot;
    * if it has shrunk, this does nothing and lets in-flight drain naturally.
+   *
+   * <p>While {@link #draining} is set, no Pulls are sent — the server stops dispatching new items,
+   * so the in-flight set monotonically drains. Results and Acks for work already in flight still
+   * flow through {@link #send(WorkRequest)}.
    */
   private void refillToTarget() {
+    if (draining.get()) {
+      return;
+    }
     int target = capacityTarget();
     int outstanding = outstandingCredits.get();
     int delta = target - outstanding;
@@ -794,11 +851,85 @@ public final class WorkStreamClient implements AutoCloseable {
     }
   }
 
+  /**
+   * Graceful shutdown. Stops pulling new work, waits up to {@link #shutdownDrainTimeout} for
+   * in-flight plugin handlers to finish and send their Results/Acks, then half-closes the stream
+   * and tears down the channel. Safe to call multiple times.
+   *
+   * <p>Sequence (differences from a naive close):
+   *
+   * <ol>
+   *   <li>Flip {@code draining} — {@link #refillToTarget} stops issuing Pulls, so the server's
+   *       event poller stops dispatching to this client.
+   *   <li>Set {@code running=false} so the reconnect loop won't respawn the stream if the server
+   *       half-closes during drain.
+   *   <li>Submit a drain task to an ephemeral single-thread executor, bounded by {@link
+   *       #shutdownDrainTimeout}. The task calls {@code workerPool.close()} which waits for
+   *       in-flight plugin handlers. Handler completion runs the normal finally block, which sends
+   *       Result/Ack via the still-live request observer.
+   *   <li>If the timeout elapses, force {@code workerPool.shutdownNow()} — pending tasks are
+   *       cancelled. Anything that didn't drain in time becomes a server-side lease expiry and will
+   *       be re-delivered on the next connect.
+   *   <li>Half-close the outbound stream via {@code onCompleted}, then shutdown the channel.
+   * </ol>
+   */
   @Override
   public void close() {
+    if (!draining.compareAndSet(false, true)) {
+      // Already closing — wait for the first caller to finish.
+      return;
+    }
+    phase = Phase.DRAINING;
     running.set(false);
-    phase = Phase.CLOSED;
-    if (streamThread != null) streamThread.interrupt();
+
+    int remaining = inflight.get();
+    log.info(
+        "WorkStream draining (inflight={}, timeout={}s)",
+        remaining,
+        shutdownDrainTimeout.toSeconds());
+
+    // Run the drain itself on a dedicated thread so the calling thread's interrupt status
+    // doesn't accidentally kill the wait. Bounded by shutdownDrainTimeout.
+    var drainer =
+        java.util.concurrent.Executors.newSingleThreadExecutor(
+            r -> {
+              var t = new Thread(r, "exile-work-stream-drain");
+              t.setDaemon(true);
+              return t;
+            });
+    var drainDone =
+        drainer.submit(
+            () -> {
+              workerPool.close();
+              return null;
+            });
+    drainer.shutdown();
+
+    boolean drained;
+    try {
+      drainDone.get(shutdownDrainTimeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+      drained = true;
+    } catch (java.util.concurrent.TimeoutException e) {
+      log.warn(
+          "WorkStream drain timed out after {}s with {} items still in flight — forcing shutdown."
+              + " Unfinished items will be re-delivered by the server after lease expiry.",
+          shutdownDrainTimeout.toSeconds(),
+          inflight.get());
+      workerPool.shutdownNow();
+      drained = false;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      workerPool.shutdownNow();
+      drained = false;
+    } catch (java.util.concurrent.ExecutionException e) {
+      log.warn("WorkStream drain failed: {}", e.getCause() != null ? e.getCause() : e);
+      drained = false;
+    } finally {
+      drainer.shutdownNow();
+    }
+
+    // Now half-close the outbound side and release the observer. After this any late Result/Ack
+    // attempt is a no-op via the null-guard in send().
     var observer = requestObserver.getAndSet(null);
     if (observer != null) {
       try {
@@ -806,7 +937,18 @@ public final class WorkStreamClient implements AutoCloseable {
       } catch (Exception ignored) {
       }
     }
-    workerPool.close();
+
+    // Interrupt the reconnect loop so it unblocks from latch.await() promptly.
+    if (streamThread != null) streamThread.interrupt();
+
+    phase = Phase.CLOSED;
     if (channel != null) ChannelFactory.shutdown(channel);
+
+    log.info(
+        "WorkStream closed (drained={}, remaining_at_start={}, completed_total={}, failed_total={})",
+        drained,
+        remaining,
+        completedTotal.get(),
+        failedTotal.get());
   }
 }

--- a/core/src/test/java/com/tcn/exile/StreamStatusTest.java
+++ b/core/src/test/java/com/tcn/exile/StreamStatusTest.java
@@ -44,6 +44,6 @@ class StreamStatusTest {
 
   @Test
   void phaseEnumValues() {
-    assertEquals(6, StreamStatus.Phase.values().length);
+    assertEquals(7, StreamStatus.Phase.values().length, "add DRAINING in v3.2");
   }
 }

--- a/core/src/test/java/com/tcn/exile/internal/WorkStreamClientShutdownTest.java
+++ b/core/src/test/java/com/tcn/exile/internal/WorkStreamClientShutdownTest.java
@@ -1,0 +1,341 @@
+package com.tcn.exile.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import build.buf.gen.tcnapi.exile.gate.v3.*;
+import com.tcn.exile.ExileConfig;
+import com.tcn.exile.StreamStatus;
+import com.tcn.exile.handler.EventHandler;
+import com.tcn.exile.handler.JobHandler;
+import com.tcn.exile.model.event.AgentCallEvent;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link WorkStreamClient#close()} graceful-drain semantics. Covers three scenarios:
+ * handlers finish and their Acks reach the server within the timeout; no Pulls are issued during
+ * drain; handlers that exceed the timeout are interrupted.
+ */
+class WorkStreamClientShutdownTest {
+
+  private static final String SERVER_NAME = "shutdown-test";
+
+  private Server server;
+  private ManagedChannel channel;
+  private ShutdownWorkerService service;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    service = new ShutdownWorkerService();
+    server =
+        InProcessServerBuilder.forName(SERVER_NAME)
+            .directExecutor()
+            .addService(service)
+            .build()
+            .start();
+    channel = InProcessChannelBuilder.forName(SERVER_NAME).directExecutor().build();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (channel != null && !channel.isShutdown()) {
+      channel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+    }
+    if (server != null) server.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Handler is running when close() starts. Drain finishes the handler normally and its Ack reaches
+   * the server before the stream half-closes.
+   */
+  @Test
+  void drain_allowsInFlightHandlerToFinishAndAck() throws Exception {
+    var handlerEntered = new CountDownLatch(1);
+    var handlerRelease = new CountDownLatch(1);
+    var handlerExited = new AtomicBoolean(false);
+
+    EventHandler eventHandler =
+        new EventHandler() {
+          @Override
+          public void onAgentCall(AgentCallEvent event) {
+            handlerEntered.countDown();
+            try {
+              handlerRelease.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } finally {
+              handlerExited.set(true);
+            }
+          }
+        };
+
+    var client =
+        new WorkStreamClient(
+            dummyConfig(),
+            new JobHandler() {},
+            eventHandler,
+            () -> 10,
+            "test",
+            "1.0",
+            100,
+            List.of(),
+            Duration.ofSeconds(5));
+    client.start(channel);
+
+    assertTrue(service.registeredLatch.await(5, TimeUnit.SECONDS), "registered");
+    service.sendWorkItem("w-drain-1", WorkCategory.WORK_CATEGORY_EVENT);
+    assertTrue(handlerEntered.await(5, TimeUnit.SECONDS), "handler running");
+
+    // Kick off close on a background thread; give the handler a moment then release it.
+    var closeThread = new Thread(client::close, "test-closer");
+    closeThread.start();
+
+    // Small pause lets close() flip draining=true and reach workerPool.close().
+    Thread.sleep(100);
+    assertEquals(
+        StreamStatus.Phase.DRAINING,
+        client.status().phase(),
+        "stream should be DRAINING while waiting for handler");
+
+    handlerRelease.countDown();
+    closeThread.join(TimeUnit.SECONDS.toMillis(6));
+    assertFalse(closeThread.isAlive(), "close() should return promptly once handler returns");
+
+    assertTrue(handlerExited.get(), "handler ran to completion");
+    assertEquals(StreamStatus.Phase.CLOSED, client.status().phase());
+
+    // The server should have received an Ack for the event before the stream closed.
+    assertTrue(
+        waitForCondition(() -> service.acked.contains("w-drain-1"), 2000),
+        "server should receive Ack for in-flight event; got acks=" + service.acked);
+  }
+
+  /** No further Pulls should leave the client while draining. */
+  @Test
+  void drain_suppressesFurtherPulls() throws Exception {
+    var handlerEntered = new CountDownLatch(1);
+    var handlerRelease = new CountDownLatch(1);
+
+    EventHandler eventHandler =
+        new EventHandler() {
+          @Override
+          public void onAgentCall(AgentCallEvent event) {
+            handlerEntered.countDown();
+            try {
+              handlerRelease.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
+          }
+        };
+
+    var client =
+        new WorkStreamClient(
+            dummyConfig(),
+            new JobHandler() {},
+            eventHandler,
+            () -> 5,
+            "test",
+            "1.0",
+            100,
+            List.of(),
+            Duration.ofSeconds(5));
+    client.start(channel);
+
+    assertTrue(service.registeredLatch.await(5, TimeUnit.SECONDS));
+    // Initial refill should have sent a Pull(5).
+    assertTrue(
+        waitForCondition(() -> service.totalPullCount() >= 5, 2000),
+        "initial pull(5); got " + service.totalPullCount());
+
+    service.sendWorkItem("w-suppress-1", WorkCategory.WORK_CATEGORY_EVENT);
+    assertTrue(handlerEntered.await(5, TimeUnit.SECONDS));
+
+    int pullCountBeforeClose = service.totalPullCount();
+    var closeThread = new Thread(client::close);
+    closeThread.start();
+
+    // Give close() time to set draining=true.
+    Thread.sleep(150);
+
+    // Release the handler. refillToTarget runs in the finally block, and must see draining=true.
+    handlerRelease.countDown();
+    closeThread.join(TimeUnit.SECONDS.toMillis(6));
+
+    assertEquals(
+        pullCountBeforeClose,
+        service.totalPullCount(),
+        "no new Pulls should be sent while draining; pre-close="
+            + pullCountBeforeClose
+            + " post-close="
+            + service.totalPullCount());
+  }
+
+  /**
+   * A stuck handler past the drain timeout should trigger workerPool.shutdownNow and unblock the
+   * close() call. The close() caller should return in ~timeout wall time.
+   */
+  @Test
+  void drain_timeoutForcesShutdownWhenHandlerWedged() throws Exception {
+    var handlerEntered = new CountDownLatch(1);
+    var handlerInterrupted = new AtomicBoolean(false);
+    // Handler that blocks "forever" but respects interrupt.
+    EventHandler eventHandler =
+        new EventHandler() {
+          @Override
+          public void onAgentCall(AgentCallEvent event) {
+            handlerEntered.countDown();
+            try {
+              Thread.sleep(30_000);
+            } catch (InterruptedException e) {
+              handlerInterrupted.set(true);
+              Thread.currentThread().interrupt();
+            }
+          }
+        };
+
+    var client =
+        new WorkStreamClient(
+            dummyConfig(),
+            new JobHandler() {},
+            eventHandler,
+            () -> 10,
+            "test",
+            "1.0",
+            100,
+            List.of(),
+            Duration.ofMillis(500));
+    client.start(channel);
+
+    assertTrue(service.registeredLatch.await(5, TimeUnit.SECONDS));
+    service.sendWorkItem("w-wedged", WorkCategory.WORK_CATEGORY_EVENT);
+    assertTrue(handlerEntered.await(5, TimeUnit.SECONDS));
+
+    long startMs = System.currentTimeMillis();
+    client.close();
+    long elapsedMs = System.currentTimeMillis() - startMs;
+
+    assertTrue(
+        elapsedMs < 3_000,
+        "close() should return within a few seconds of the 500ms timeout; took "
+            + elapsedMs
+            + "ms");
+    assertEquals(StreamStatus.Phase.CLOSED, client.status().phase());
+    // Handler should have been interrupted by shutdownNow.
+    assertTrue(
+        waitForCondition(handlerInterrupted::get, 2000),
+        "wedged handler should be interrupted after drain timeout");
+  }
+
+  // --- helpers ---
+
+  private static ExileConfig dummyConfig() {
+    return ExileConfig.builder()
+        .rootCert("unused")
+        .publicCert("unused")
+        .privateKey("unused")
+        .apiHostname("in-process")
+        .apiPort(0)
+        .build();
+  }
+
+  private static boolean waitForCondition(java.util.function.BooleanSupplier cond, long ms)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + ms;
+    while (System.currentTimeMillis() < deadline) {
+      if (cond.getAsBoolean()) return true;
+      Thread.sleep(10);
+    }
+    return cond.getAsBoolean();
+  }
+
+  /**
+   * In-process WorkerService with manual WorkItem delivery and tracking of Ack messages. Same shape
+   * as WorkStreamClientRefillTest's ManualWorkerService plus explicit Ack recording.
+   */
+  static class ShutdownWorkerService extends WorkerServiceGrpc.WorkerServiceImplBase {
+    final CopyOnWriteArrayList<Integer> pullCounts = new CopyOnWriteArrayList<>();
+    final CopyOnWriteArrayList<String> acked = new CopyOnWriteArrayList<>();
+    final CopyOnWriteArrayList<String> resulted = new CopyOnWriteArrayList<>();
+    final CountDownLatch registeredLatch = new CountDownLatch(1);
+    private volatile StreamObserver<WorkResponse> activeObserver;
+
+    int totalPullCount() {
+      return pullCounts.stream().mapToInt(Integer::intValue).sum();
+    }
+
+    void sendWorkItem(String workId, WorkCategory category) {
+      var obs = activeObserver;
+      if (obs == null) throw new IllegalStateException("No active stream");
+      var b = WorkItem.newBuilder().setWorkId(workId).setCategory(category).setAttempt(1);
+      if (category == WorkCategory.WORK_CATEGORY_JOB) {
+        b.setListPools(ListPoolsTask.getDefaultInstance());
+      } else {
+        b.setAgentCall(AgentCall.newBuilder().setCallSid(1).setAgentCallSid(1));
+      }
+      obs.onNext(WorkResponse.newBuilder().setWorkItem(b.build()).build());
+    }
+
+    @Override
+    public StreamObserver<WorkRequest> workStream(StreamObserver<WorkResponse> responseObserver) {
+      activeObserver = responseObserver;
+      return new StreamObserver<>() {
+        @Override
+        public void onNext(WorkRequest request) {
+          if (request.hasRegister()) {
+            responseObserver.onNext(
+                WorkResponse.newBuilder()
+                    .setRegistered(
+                        Registered.newBuilder()
+                            .setClientId("shutdown-" + System.nanoTime())
+                            .setHeartbeatInterval(
+                                com.google.protobuf.Duration.newBuilder().setSeconds(300))
+                            .setDefaultLease(
+                                com.google.protobuf.Duration.newBuilder().setSeconds(300))
+                            .setMaxInflight(100))
+                    .build());
+            registeredLatch.countDown();
+          } else if (request.hasPull()) {
+            pullCounts.add(request.getPull().getMaxItems());
+          } else if (request.hasAck()) {
+            acked.addAll(request.getAck().getWorkIdsList());
+          } else if (request.hasResult()) {
+            var workId = request.getResult().getWorkId();
+            resulted.add(workId);
+            responseObserver.onNext(
+                WorkResponse.newBuilder()
+                    .setResultAccepted(ResultAccepted.newBuilder().setWorkId(workId))
+                    .build());
+          }
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {
+          responseObserver.onCompleted();
+        }
+      };
+    }
+  }
+
+  // Unused helper kept for potential future wire-level assertions.
+  @SuppressWarnings("unused")
+  private static AtomicInteger counter() {
+    return new AtomicInteger();
+  }
+}


### PR DESCRIPTION
## Summary

Makes `ExileClient.close()` drain in-flight work gracefully instead of dropping Result/Ack messages. Prevents the "finish locally but have the gate re-dispatch everything" duplication pattern on deploys/restarts.

## The bug

The previous `close()` sequence was:

```java
requestObserver.getAndSet(null);   // 1. null the observer
observer.onCompleted();             // 2. half-close the stream
workerPool.close();                 // 3. WAIT for handlers to finish
```

Problem: step 1 happens **before** step 3. Every handler that completes during drain then calls:

```java
var observer = requestObserver.get();   // null
if (observer != null) { ... }           // no-op
```

So the handler runs to completion locally but its `Result`/`Ack` never reaches the server. The server lease-expires and re-delivers to this client on the next connect (or to another replica). Net effect: at-least-once duplication every time anyone does a graceful deploy.

## The fix

1. New `AtomicBoolean draining` flag. `refillToTarget()` checks it and stops issuing `Pull` — the gate's event poller stops dispatching to this client.
2. `running = false` so the reconnect loop won't respawn the stream if the server half-closes during drain.
3. `workerPool.close()` runs on a dedicated thread with a bounded wait (default 30s, configurable). In-flight plugin handlers complete normally; their finally blocks send `Result`/`Ack` through the still-live observer.
4. If the timeout elapses, `workerPool.shutdownNow()` interrupts wedged handlers. Whatever didn't drain becomes server-side lease expiry and is re-delivered — bounded worst case, never worse than today's behaviour.
5. **Only after** drain do we half-close via `observer.onCompleted()` and shut down the channel.

## API additions

- `StreamStatus.Phase.DRAINING` — ordinal 6, **appended** so existing `exile.work.phase` gauge consumers aren't broken by an enum shift.
- `ExileClient.Builder.shutdownDrainTimeout(Duration)` — default 30s; `Duration.ZERO` disables drain (legacy behaviour — in-flight handlers still run but results may be lost).
- New `WorkStreamClient` public constant `DEFAULT_SHUTDOWN_DRAIN_TIMEOUT = 30s`.
- New `WorkStreamClient` 9-arg constructor that takes the drain timeout (older 8-arg and 7-arg constructors delegate with the default, so existing callers are untouched).
- `MetricsManager` gauge description updated: `"... 5=CLOSED, 6=DRAINING"`.

No breaking changes.

## Tests

`WorkStreamClientShutdownTest` — 3 new tests against an in-process gRPC server:

- `drain_allowsInFlightHandlerToFinishAndAck` — close() with a running handler; handler finishes normally; server receives the Ack before the stream closes. Status phase transitions `ACTIVE → DRAINING → CLOSED`.
- `drain_suppressesFurtherPulls` — while draining, no additional `Pull` messages leave the client. Verified by counting Pulls before/after close().
- `drain_timeoutForcesShutdownWhenHandlerWedged` — handler that sleeps for 30s with a 500ms drain timeout; close() returns within ~3s, the handler is interrupted, and `Phase.CLOSED` is set.

Also updated `StreamStatusTest.phaseEnumValues()` from 6 → 7 to reflect the new enum value.

## Test plan

- [x] `./gradlew :core:check` — 114 tests pass (added 3, updated 1).
- [x] Spotless clean.
- [x] Backwards compatible — no breaking API changes, no dashboard shifts (DRAINING appended, not inserted).
- [ ] E2E: finvi restart with `maxConcurrency` worth of in-flight work → server shows all items Ack'd before disconnect.

## Related

- Downstream: this unblocks finvi (`tcncloud/finvi`) to add its own `@PreDestroy` on the Plugin so the `PriorityExecutor` also drains — follow-up PR.
