### PR TITLE
fix(adaptive): min-gradient collapse on heterogeneous workloads

### DIFF
--- a/core/src/main/java/com/tcn/exile/internal/AdaptiveCapacity.java
+++ b/core/src/main/java/com/tcn/exile/internal/AdaptiveCapacity.java
@@ -5,7 +5,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -22,8 +21,11 @@ import org.slf4j.LoggerFactory;
  *
  * <ul>
  *   <li><b>SLO gradient</b>: {@code min(1, SLO / jobP95)} — absolute 500 ms budget.
- *   <li><b>Min gradient</b>: {@code min(1, decayingMinJob / jobEMA)} — Vegas-style relative signal
- *       detecting queueing buildup.
+ *   <li><b>Min gradient</b>: {@code min(1, fastCase / jobEMA)} — Vegas-style relative signal
+ *       detecting queueing buildup. {@code fastCase} is {@code max(p5, 1 ms)} off the job-latency
+ *       ring buffer — a resilient "realistic fast-case" that can't be pinned by a single
+ *       sub-millisecond outlier (cache hits, empty lists, fast-fails) the way a true decaying
+ *       minimum could.
  *   <li><b>Resource gradient</b>: derived from any declared {@link ResourceLimit} that reports
  *       {@code currentUsage}; sheds as utilization climbs past 70 %.
  * </ul>
@@ -52,6 +54,22 @@ public final class AdaptiveCapacity implements IntSupplier {
   static final double UTIL_SHED_START = 0.70;
   static final double UTIL_SHED_FULL = 1.00;
 
+  /**
+   * "Fast-case" reference point for the min-gradient, as a percentile of the recent job latency
+   * ring buffer. p5 resists single-outlier pinning (you need ≥ 5 % of the window to be at that
+   * speed for p5 to move there) while still tracking the genuine fast-case of a diverse workload.
+   */
+  static final double FAST_CASE_PERCENTILE = 0.05;
+
+  /**
+   * Minimum "fast-case" latency the min-gradient will consider. Sub-millisecond job handlers (cache
+   * hits, empty results) are not representative of the plugin's real throughput capacity, so
+   * treating them as the fast-case causes the min-gradient to permanently floor at its 0.5 cap —
+   * the controller then halves the limit every recompute until it collapses to {@code minLimit}.
+   * Clamping the fast-case up to this floor eliminates that degeneracy.
+   */
+  static final long MIN_GRADIENT_NOISE_FLOOR_NANOS = 1_000_000L; // 1 ms
+
   private final int minLimit;
   private final int maxLimit;
   private final Supplier<List<ResourceLimit>> resourceSupplier;
@@ -59,7 +77,6 @@ public final class AdaptiveCapacity implements IntSupplier {
   private volatile int limit;
 
   private final RingBuffer jobLatencies = new RingBuffer(WINDOW);
-  private final AtomicLong decayingMinJob = new AtomicLong(Long.MAX_VALUE);
   private volatile double emaJobRtt;
   private final AtomicInteger jobSamples = new AtomicInteger();
   private final AtomicInteger errorCount = new AtomicInteger();
@@ -108,7 +125,6 @@ public final class AdaptiveCapacity implements IntSupplier {
     if (nanos < 0) nanos = 0;
     jobLatencies.add(nanos);
     updateEma(nanos);
-    updateDecayingMin(nanos);
 
     int n = jobSamples.incrementAndGet();
     if (n >= MIN_SAMPLES && n % RECOMPUTE_EVERY == 0) {
@@ -127,16 +143,15 @@ public final class AdaptiveCapacity implements IntSupplier {
   }
 
   /**
-   * Updates the decaying minimum. The previous value drifts upward by ~0.1 % per sample (added
-   * {@code prev >> 10}) before being replaced if the new sample is lower. This lets a single
-   * exceptionally-fast early sample age out over time instead of pinning the min forever.
+   * The "fast-case" job latency used by the min-gradient: the 5th-percentile of the recent ring
+   * buffer, clamped up to {@link #MIN_GRADIENT_NOISE_FLOOR_NANOS}. Single sub-millisecond outliers
+   * can't pin this the way a true running minimum can. Returns {@code 0} before the ring buffer has
+   * any samples — callers must handle that case.
    */
-  private void updateDecayingMin(long sample) {
-    decayingMinJob.updateAndGet(
-        prev -> {
-          long drifted = (prev == Long.MAX_VALUE) ? Long.MAX_VALUE : prev + (prev >> 10);
-          return Math.min(drifted, sample);
-        });
+  private long fastCaseNanos() {
+    long p5 = jobLatencies.percentile(FAST_CASE_PERCENTILE);
+    if (p5 <= 0) return 0;
+    return Math.max(p5, MIN_GRADIENT_NOISE_FLOOR_NANOS);
   }
 
   private void onError() {
@@ -146,17 +161,30 @@ public final class AdaptiveCapacity implements IntSupplier {
 
   private void recompute() {
     long p95 = jobLatencies.percentile(0.95);
+    long p5 = jobLatencies.percentile(FAST_CASE_PERCENTILE);
     double ema = emaJobRtt;
     if (p95 <= 0 || ema <= 0) {
       return;
     }
-    long minRtt = decayingMinJob.get();
-    if (minRtt == Long.MAX_VALUE) {
-      minRtt = p95; // no observation yet — neutral value
-    }
+    long fastCase = Math.max(p5 > 0 ? p5 : p95, MIN_GRADIENT_NOISE_FLOOR_NANOS);
 
     double sloG = clamp((double) SLO_NANOS / p95, GRADIENT_FLOOR, 1.0);
-    double minG = clamp((double) minRtt / ema, GRADIENT_FLOOR, 1.0);
+
+    // Homogeneity guard: min-gradient is the Vegas-style "queueing detector" — it assumes
+    // the fast-case latency is a meaningful reference for the EMA. That assumption holds for
+    // homogeneous workloads (every call does roughly the same work), but not for plugins that
+    // mix sub-ms cache hits with tens-of-ms JDBC calls: the ratio then reflects workload
+    // variance rather than queueing. We detect that by comparing p5 to p95 — when p5/p95 is
+    // below the gradient floor (i.e. the ratio would peg at 0.5 regardless of EMA) we skip
+    // the signal and let the SLO/resource gradients drive the limit alone.
+    double homogeneity = (double) p5 / (double) p95;
+    double minG;
+    if (homogeneity < GRADIENT_FLOOR) {
+      minG = 1.0; // workload too heterogeneous; trust SLO + resource signals instead.
+    } else {
+      minG = clamp((double) fastCase / ema, GRADIENT_FLOOR, 1.0);
+    }
+
     double resG = computeResourceGradient();
     double gradient = Math.min(Math.min(sloG, minG), resG);
 
@@ -173,13 +201,15 @@ public final class AdaptiveCapacity implements IntSupplier {
     limit = clamped;
     if (log.isDebugEnabled() && old != clamped) {
       log.debug(
-          "adaptive limit {} -> {} (p95={}ms, ema={}ms, min={}ms, sloG={}, minG={}, resG={},"
-              + " ceiling={})",
+          "adaptive limit {} -> {} (p95={}ms, p5={}ms, ema={}ms, fastCase={}ms, homogeneity={},"
+              + " sloG={}, minG={}, resG={}, ceiling={})",
           old,
           clamped,
           p95 / 1_000_000,
+          p5 / 1_000_000,
           (long) ema / 1_000_000,
-          minRtt / 1_000_000,
+          fastCase / 1_000_000,
+          String.format("%.2f", homogeneity),
           String.format("%.2f", sloG),
           String.format("%.2f", minG),
           String.format("%.2f", resG),
@@ -249,9 +279,14 @@ public final class AdaptiveCapacity implements IntSupplier {
     return (long) emaJobRtt;
   }
 
+  /**
+   * Returns the "fast-case" latency used by the min-gradient — p5 of the recent job latencies,
+   * clamped up to a 1 ms noise floor. Named {@code decayingMinNanos} for backwards compatibility
+   * with {@link com.tcn.exile.AdaptiveSnapshot} (this method was originally a literal decaying
+   * minimum; it was replaced with p5-plus-floor to eliminate the single-outlier pin pathology).
+   */
   public long decayingMinNanos() {
-    long v = decayingMinJob.get();
-    return v == Long.MAX_VALUE ? 0 : v;
+    return fastCaseNanos();
   }
 
   public double lastSloGradient() {

--- a/core/src/test/java/com/tcn/exile/internal/AdaptiveCapacityTest.java
+++ b/core/src/test/java/com/tcn/exile/internal/AdaptiveCapacityTest.java
@@ -164,6 +164,82 @@ class AdaptiveCapacityTest {
     assertEquals(Duration.ofMillis(500).toNanos(), SLO_NANOS);
   }
 
+  // --- Regression: min-gradient collapse on heterogeneous workloads ---
+  //
+  // These tests cover the bug reproduced live against finvi: a single sub-ms
+  // sample pinned decayingMin at its bit-shift fixed-point, the min-gradient
+  // permanently floored at 0.5, and the limit halved every recompute until
+  // it collapsed to minLimit. Fixed by replacing the running decaying min
+  // with p5 of the ring buffer clamped up to a 1 ms noise floor.
+
+  /** A single very-fast sample (cache hit) must not permanently pin the "fast case". */
+  @Test
+  void singleSubMsOutlierDoesNotPinFastCase() {
+    var a = new AdaptiveCapacity(1, 50, 200, List::of);
+    // One sub-ms sample followed by many normal-latency samples.
+    a.recordJobCompletion(100_000L, true); // 0.1 ms (cache hit)
+    feed(a, 20 * MS, 200);
+    // decayingMinNanos() now returns max(p5, 1 ms). p5 of a window with 99%
+    // of samples at 20 ms and 1 at 0.1 ms is 20 ms (the one outlier sits far
+    // below p5). fastCase >= 1 ms from the noise floor regardless.
+    assertTrue(
+        a.decayingMinNanos() >= MIN_GRADIENT_NOISE_FLOOR_NANOS,
+        "fast-case should be clamped above the noise floor; got "
+            + a.decayingMinNanos() / 1_000_000
+            + "ms");
+    assertTrue(
+        a.decayingMinNanos() >= 10 * MS,
+        "fast-case (p5) should reflect the majority workload, not the single outlier; got "
+            + a.decayingMinNanos() / 1_000_000
+            + "ms");
+  }
+
+  /**
+   * Heterogeneous workload: 30 % cache hits at 0.1 ms and 70 % real work at 20 ms, with plenty of
+   * SLO headroom and no errors. The pre-fix controller collapsed the limit to 1 over ~100 samples
+   * because min-gradient pinned at 0.5 every recompute. Post-fix the limit should stay near the
+   * initial value.
+   */
+  @Test
+  void heterogeneousWorkloadDoesNotCollapseToMinLimit() {
+    var a = new AdaptiveCapacity(1, 50, 200, List::of);
+    // 500 samples: 30% sub-ms (cache hits), 70% at 20ms (real DB work). Alternating so the
+    // ring buffer sees both consistently.
+    for (int i = 0; i < 500; i++) {
+      long sample = (i % 10 < 3) ? 100_000L /* 0.1 ms */ : 20 * MS;
+      a.recordJobCompletion(sample, true);
+    }
+    assertTrue(
+        a.limit() > 1,
+        "limit should not collapse to minLimit on a heterogeneous workload with SLO"
+            + " headroom; got limit="
+            + a.limit()
+            + " (ema="
+            + a.jobEmaNanos() / 1_000_000
+            + "ms, p95="
+            + a.jobP95Nanos() / 1_000_000
+            + "ms, fastCase="
+            + a.decayingMinNanos() / 1_000_000
+            + "ms, minG="
+            + a.lastMinGradient()
+            + ")");
+    // SLO comfortable (way under 500 ms), so sloGradient should be 1.0 —
+    // min-gradient is the only thing that could have sheared.
+    assertEquals(1.0, a.lastSloGradient(), 1e-9);
+  }
+
+  /**
+   * Regression lock-in: 100 % cache-hit workload (every sample ≤ 1 ms). The noise floor should keep
+   * the min-gradient near 1.0 by treating all samples as equally "fast" relative to the floor,
+   * avoiding a degenerate shed on a plugin that's genuinely always fast.
+   */
+  @Test
+  void allSubMsSamplesDoNotCollapseLimit() {
+    var a = new AdaptiveCapacity(1, 50, 200, List::of);
+    feed(a, 500_000L /* 0.5 ms */, 500);
+    assertTrue(a.limit() > 1, "uniformly fast workload should not shed; got limit=" + a.limit());
+  }
+
   // --- Helper ---
 
   private static void feed(AdaptiveCapacity a, long nanos, int count) {


### PR DESCRIPTION
## Summary

Fixes a reproducible "limit always collapses to 1" bug in `AdaptiveCapacity` that was observed live against finvi during load testing. No public API changes.

## The bug, reproduced live

Against a warm finvi instance driving ~40 `ListPools` calls/min via `exilectl`:

```
16:35:17  samples=0    limit=10   (start)
16:36:00  samples=37   limit=5    first recompute
16:36:31  samples=50   limit=3
16:37:17  samples=75   limit=2
16:38:19  samples=100  limit=1    ← collapsed
```

Throughout:
- `sloGradient = 1.0` (p95 = 47 ms, 9 % of the 500 ms SLO — no SLO pressure)
- `resourceGradient = 1.0` (DB pool had 16-slot headroom)
- `errorCount = 0` (no plugin failures)
- `minGradient = 0.5` floor, **this alone** drove the shed

The controller was doing exactly what the algorithm said — but the algorithm was wrong for finvi's workload.

## Root cause

Two interlocking issues:

**1. Single sub-ms outlier pins the running minimum forever.** The `decayingMin` drift logic is:
```java
decayingMin = Math.min(prev + (prev >> 10), sample);
```
At `prev ≤ 1023 nanos`, `prev >> 10 = 0`, so the drift is zero. Once a cache-hit sample pegs `decayingMin` at ~1 ns, it stays there for the process lifetime, and every subsequent real sample makes the `min/EMA` ratio tiny → clamped to the 0.5 gradient floor → limit halved every recompute.

**2. Even without the pin, the min-gradient assumption doesn't hold for heterogeneous workloads.** Vegas-style congestion detection compares "fastest observed" to "current average" and infers queueing when the gap grows. That works when every sample represents the same kind of work. It breaks when a single method alternates between a sub-ms cache-hit path and a tens-of-ms DB path — the ratio then reflects workload variance rather than congestion.

## Fix

Two changes to `AdaptiveCapacity`:

### 1. Replace `decayingMin` with `p5` off the existing ring buffer, clamped up to a 1 ms noise floor

```java
long p5 = jobLatencies.percentile(FAST_CASE_PERCENTILE);  // 0.05
long fastCase = Math.max(p5, MIN_GRADIENT_NOISE_FLOOR_NANOS);  // 1 ms
```

- Removes the `AtomicLong decayingMinJob` field, the `updateDecayingMin()` method, and the bit-shift drift math entirely.
- p5 can't be pinned by a single outlier — needs ≥ 5 % of the window to move there.
- The 1 ms noise floor prevents a cache-hit-only plugin (where p5 is genuinely sub-ms) from feeding a degenerate fast-case into the ratio.

### 2. Homogeneity guard — skip min-gradient when the workload is too variable

```java
double homogeneity = (double) p5 / (double) p95;
double minG;
if (homogeneity < GRADIENT_FLOOR) {
    minG = 1.0;  // too heterogeneous; trust SLO + resource signals
} else {
    minG = clamp((double) fastCase / ema, GRADIENT_FLOOR, 1.0);
}
```

When p5 is far below p95 (wide latency variance from mixed fast/slow paths), the ratio doesn't mean what Vegas thinks it means. The gradient floor is 0.5, so using that same threshold for "homogeneous enough" keeps one tunable.

For finvi's observed numbers (p5 ≈ 1 ms, p95 ≈ 47 ms): `1/47 = 0.02 < 0.5` → skip min-gradient → no shed → SLO + resource gradients keep doing their job.

For homogeneous workloads where min-gradient genuinely catches queueing: p5 and p95 are close (e.g., `40/50 = 0.8`), the guard doesn't trigger, and the signal works as before.

## Backwards compatibility

- **No public API changes.** `AdaptiveCapacity.decayingMinNanos()` is preserved (used by `AdaptiveSnapshot.decayingMinNanos` on the dashboard). It now returns `max(p5, noiseFloor)` — a semantically closer-to-intended "realistic fast-case" value rather than the literal running minimum. The name is a historical artifact.
- **Homogeneous workloads unaffected.** The homogeneity check gates the gradient; when the workload is uniform, p5 ≈ p95 > 0.5 ratio, and the gradient runs as before.
- **Error-shed path unchanged.** The ×0.5-on-error path is orthogonal to the min-gradient.

## Tests

Three new regression tests in `AdaptiveCapacityTest` locking in the reproduction:

- `singleSubMsOutlierDoesNotPinFastCase` — one 0.1 ms sample + 200 samples at 20 ms; `decayingMinNanos()` must not be pinned low.
- `heterogeneousWorkloadDoesNotCollapseToMinLimit` — 30 % cache hits + 70 % real work over 500 samples; `limit` must stay > 1 with `sloGradient = 1.0`.
- `allSubMsSamplesDoNotCollapseLimit` — uniform sub-ms workload; noise floor prevents degenerate shed.

All existing tests pass unchanged. `:core:check` green.

## Related

- Epic: https://git.tcncloud.net/groups/exile/-/epics/9
- Previous C2 PR introduced this bug's logic: #50 (merged to v3.1+). This PR fixes it.
