### PR TITLE
feat(tracing): export spans to GCP Cloud Trace when opted in

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,12 @@ dependencies {
 	implementation("io.opentelemetry:opentelemetry-sdk-metrics:1.61.0")
 	implementation("io.opentelemetry:opentelemetry-sdk-trace:1.61.0")
 
+	// GCP Cloud Trace exporter (direct — same approach the Go side uses in
+	// git.tcncloud.net/utils/fxmodules/tracing/gcp). Only instantiated when
+	// tracing.samplingFraction > 0 on the ExileClient builder, so plugins that
+	// don't opt in pay nothing and don't need GCP credentials to start.
+	implementation("com.google.cloud.opentelemetry:exporter-trace:0.36.0")
+
 	// PKCS#1 → PKCS#8 key conversion for mTLS
 	implementation("org.bouncycastle:bcpkix-jdk18on:1.83")
 

--- a/core/src/main/java/com/tcn/exile/ExileClient.java
+++ b/core/src/main/java/com/tcn/exile/ExileClient.java
@@ -55,6 +55,7 @@ public final class ExileClient implements AutoCloseable {
   private final TelemetryService telemetryService;
   private final String telemetryClientId;
   private final AdaptiveCapacity adaptive; // null when caller overrode or disabled
+  private final double tracingSamplingFraction;
   private volatile MetricsManager metricsManager;
 
   private volatile ConfigService.ClientConfiguration lastConfig;
@@ -65,6 +66,7 @@ public final class ExileClient implements AutoCloseable {
     this.config = builder.config;
     this.plugin = builder.plugin;
     this.configPollInterval = builder.configPollInterval;
+    this.tracingSamplingFraction = builder.tracingSamplingFraction;
 
     var choice = chooseCapacityProvider(builder, plugin);
     IntSupplier capacity = choice.provider();
@@ -184,7 +186,8 @@ public final class ExileClient implements AutoCloseable {
                 telemetryClientId,
                 newConfig.orgId(),
                 config.certificateName(),
-                workStream::status);
+                workStream::status,
+                tracingSamplingFraction);
         workStream.setDurationRecorder(metricsManager::recordWorkDuration);
         workStream.setMethodRecorder(metricsManager::recordMethodCall);
         workStream.setReconnectRecorder(metricsManager::recordReconnectDuration);
@@ -357,6 +360,7 @@ public final class ExileClient implements AutoCloseable {
     private Duration configPollInterval = Duration.ofSeconds(10);
     private Duration shutdownDrainTimeout =
         com.tcn.exile.internal.WorkStreamClient.DEFAULT_SHUTDOWN_DRAIN_TIMEOUT;
+    private double tracingSamplingFraction = 0.0;
 
     private Builder() {}
 
@@ -451,6 +455,25 @@ public final class ExileClient implements AutoCloseable {
      */
     public Builder shutdownDrainTimeout(Duration timeout) {
       this.shutdownDrainTimeout = Objects.requireNonNull(timeout);
+      return this;
+    }
+
+    /**
+     * Fraction of traces to sample and export to GCP Cloud Trace. {@code 0.0} (default) disables
+     * tracing entirely — no GCP client is instantiated, no spans are exported, plugins that don't
+     * opt in pay nothing. {@code 1.0} samples every trace, appropriate for dev. Production usage
+     * should use a small fraction (e.g. {@code 0.01}–{@code 0.1}) to stay under Cloud Trace
+     * ingestion limits. The sampler is {@code ParentBased(TraceIdRatioBased(fraction))}, so spans
+     * already sampled upstream (by the exile gatev3 server) are always exported regardless of the
+     * fraction here.
+     *
+     * @throws IllegalArgumentException if {@code fraction} is outside [0.0, 1.0]
+     */
+    public Builder tracingSamplingFraction(double fraction) {
+      if (fraction < 0.0 || fraction > 1.0) {
+        throw new IllegalArgumentException("tracingSamplingFraction must be in [0.0, 1.0]");
+      }
+      this.tracingSamplingFraction = fraction;
       return this;
     }
 

--- a/core/src/main/java/com/tcn/exile/internal/MetricsManager.java
+++ b/core/src/main/java/com/tcn/exile/internal/MetricsManager.java
@@ -1,5 +1,7 @@
 package com.tcn.exile.internal;
 
+import com.google.cloud.opentelemetry.trace.TraceConfiguration;
+import com.google.cloud.opentelemetry.trace.TraceExporter;
 import com.tcn.exile.StreamStatus;
 import com.tcn.exile.service.TelemetryService;
 import io.opentelemetry.api.common.AttributeKey;
@@ -7,11 +9,16 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -50,6 +57,26 @@ public final class MetricsManager implements AutoCloseable {
       String orgId,
       String certificateName,
       Supplier<StreamStatus> statusSupplier) {
+    this(telemetryService, clientId, orgId, certificateName, statusSupplier, 0.0);
+  }
+
+  /**
+   * Tracing-aware constructor.
+   *
+   * @param tracingSamplingFraction 0.0 → no spans exported (TracerProvider runs with {@link
+   *     Sampler#alwaysOff()} and no exporter is instantiated). {@code 0 < f ≤ 1.0} → install a
+   *     {@link TraceExporter GCP Cloud Trace exporter} as a {@link BatchSpanProcessor} and use
+   *     {@code ParentBased(TraceIdRatioBased(f))} for head-sampling. Any exporter construction
+   *     failure (missing GCP credentials, misconfigured project, etc.) is logged and downgraded to
+   *     "no exporter" rather than aborting MetricsManager startup.
+   */
+  public MetricsManager(
+      TelemetryService telemetryService,
+      String clientId,
+      String orgId,
+      String certificateName,
+      Supplier<StreamStatus> statusSupplier,
+      double tracingSamplingFraction) {
 
     var exporter = new GrpcMetricExporter(telemetryService, clientId);
     var reader = PeriodicMetricReader.builder(exporter).setInterval(Duration.ofSeconds(60)).build();
@@ -66,8 +93,27 @@ public final class MetricsManager implements AutoCloseable {
     this.meterProvider =
         SdkMeterProvider.builder().setResource(resource).registerMetricReader(reader).build();
 
-    // TracerProvider generates valid trace/span IDs for log correlation.
-    var tracerProvider = SdkTracerProvider.builder().setResource(resource).build();
+    // TracerProvider: always built so spans can be created for log correlation, but only
+    // attached to an exporter when the caller opted into tracing via tracingSamplingFraction.
+    SdkTracerProviderBuilder tracerBuilder = SdkTracerProvider.builder().setResource(resource);
+    if (tracingSamplingFraction > 0.0) {
+      SpanExporter spanExporter = tryBuildCloudTraceExporter();
+      if (spanExporter != null) {
+        tracerBuilder
+            .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+            .setSampler(Sampler.parentBased(Sampler.traceIdRatioBased(tracingSamplingFraction)));
+        log.info(
+            "Tracing enabled: GCP Cloud Trace exporter, sampling fraction={}",
+            tracingSamplingFraction);
+      } else {
+        // Exporter failed to construct — keep the TracerProvider but drop every span by
+        // sampling at 0. The caller still gets valid trace IDs for MDC correlation.
+        tracerBuilder.setSampler(Sampler.alwaysOff());
+      }
+    } else {
+      tracerBuilder.setSampler(Sampler.alwaysOff());
+    }
+    var tracerProvider = tracerBuilder.build();
 
     var sdkBuilder =
         OpenTelemetrySdk.builder()
@@ -181,6 +227,29 @@ public final class MetricsManager implements AutoCloseable {
   /** The OTel Meter for plugin developers to create custom instruments. */
   public Meter meter() {
     return meter;
+  }
+
+  /**
+   * The OTel Tracer for plugin developers to create their own spans. When the caller did not enable
+   * tracing (sampling fraction = 0) this still returns a valid no-op tracer; plugin code can use it
+   * unconditionally.
+   */
+  public Tracer tracer() {
+    return openTelemetry.getTracer("com.tcn.exile.sati.plugin");
+  }
+
+  /**
+   * Build the GCP Cloud Trace exporter. Returns {@code null} (and logs a warning) if GCP
+   * credentials or project detection fails — this is not fatal; tracing is downgraded to no-op and
+   * everything else continues to work.
+   */
+  private static SpanExporter tryBuildCloudTraceExporter() {
+    try {
+      return TraceExporter.createWithConfiguration(TraceConfiguration.builder().build());
+    } catch (Exception e) {
+      log.warn("Could not create GCP Cloud Trace exporter ({}). Tracing disabled.", e.getMessage());
+      return null;
+    }
   }
 
   /** Record the duration of a completed work item. Called from WorkStreamClient. */


### PR DESCRIPTION
## Summary

Wire the sati client into the end-to-end trace that starts in `exile/exile` station/gatev3 and ends at the plugin handler. Pairs with https://git.tcncloud.net/exile/exile/-/merge_requests/212 — without that MR, nothing on the Go side creates a sampled span to propagate.

## Context

`MetricsManager.java` already builds an `SdkTracerProvider`, but with no span processor and no exporter — every span created via `GlobalOpenTelemetry.getTracer(...)` in `WorkStreamClient.java` is silently dropped. Meanwhile, the Go side emits a W3C `traceparent` onto every WorkItem (`dispatcher_v3.traceParentFromContext`), but sati never extracts it — so even if spans exported, they'd be disconnected orphan traces per WorkItem.

## Changes

### 1. `MetricsManager.java` — real exporter + sampler

Add the GCP Cloud Trace exporter from `io.opentelemetry.contrib:opentelemetry-gcp-trace-exporter` as a `BatchSpanProcessor` on the existing `SdkTracerProvider`. `ParentBased(TraceIdRatioBased(fraction))` sampler — fraction read from a new ExileClientBuilder option (`tracingSamplingFraction`, default 0.0). When the fraction is 0, the TracerProvider builds with a `Sampler.alwaysOff()` shortcut and the exporter isn't instantiated, so no GCP client creation in tests or in plugins that don't want tracing.

Also expose `MetricsManager.tracer()` analogous to `meter()` so plugin authors can add their own spans.

### 2. `WorkStreamClient.java` — extract traceparent, start child span

On each incoming `WorkItem`:

```java
String tp = /* WorkItem.traceparent field or metadata key */;
Context parentCtx = tp.isEmpty()
    ? Context.current()
    : W3CTraceContextPropagator.getInstance().extract(Context.current(),
          Map.of("traceparent", tp), TextMapGetter);
Span span = tracer.spanBuilder("sati.dispatch")
    .setParent(parentCtx)
    .setSpanKind(SpanKind.SERVER)
    .setAttribute("work_type", workType)
    .startSpan();
try (var scope = span.makeCurrent()) {
    // existing handler dispatch
} finally {
    span.end();
}
```

The virtual thread that runs the handler inherits the scope, so any plugin-side spans become children of `sati.dispatch` automatically.

### 3. New builder option

`ExileClientBuilder.tracingSamplingFraction(double fraction)` — 0.0 = tracing off (no GCP client spun up), 1.0 = sample every trace. Recorded in the MR description for `exile/exile` MR !212 as: dev uses 1.0, prod uses 0.0 for now.

## Test plan

- [ ] `./gradlew :core:check` green.
- [ ] Existing tests unchanged (the tracer resolves to no-op when fraction=0).
- [ ] Once the exile/exile MR lands in dev-1, run `exilectl StationApi ListPools` and verify a single trace in GCP Cloud Trace spans station → gate → sati with `sati.dispatch` as a child of `gate.dispatch`.

## Related

- `exile/exile` MR !212 — the Go side that actually creates the root span.