### PR TITLE
feat: extend TelephonyResultEvent with old call identifiers

### DIFF
--- a/core/src/main/java/com/tcn/exile/internal/ProtoConverter.java
+++ b/core/src/main/java/com/tcn/exile/internal/ProtoConverter.java
@@ -255,7 +255,9 @@ public final class ProtoConverter {
         toInstant(tr.getUpdateTime()),
         toInstant(tr.getStartTime()),
         toInstant(tr.getEndTime()),
-        toTaskData(tr.getTaskDataList()));
+        toTaskData(tr.getTaskDataList()),
+        tr.hasOldCallSid() ? tr.getOldCallSid() : 0L,
+        tr.hasOldCallType() ? toCallType(tr.getOldCallType()) : null);
   }
 
   public static AgentResponseEvent toAgentResponseEvent(

--- a/core/src/main/java/com/tcn/exile/model/event/TelephonyResultEvent.java
+++ b/core/src/main/java/com/tcn/exile/model/event/TelephonyResultEvent.java
@@ -25,4 +25,6 @@ public record TelephonyResultEvent(
     Instant updateTime,
     Instant startTime,
     Instant endTime,
-    List<TaskData> taskData) {}
+    List<TaskData> taskData,
+    long oldCallSid,
+    CallType oldCallType) {}


### PR DESCRIPTION
This pull request updates the `TelephonyResultEvent` model and its conversion logic to include additional information about previous calls. The changes ensure that both the old call SID and call type are captured and made available throughout the application.

Enhancements to telephony event data:

* Updated the `TelephonyResultEvent` record in `TelephonyResultEvent.java` to include two new fields: `oldCallSid` (a long) and `oldCallType` (a `CallType`), allowing tracking of previous call context.
* Modified the `toTelephonyResultEvent` method in `ProtoConverter.java` to extract and pass the new `oldCallSid` and `oldCallType` fields from the source object, with appropriate null and default handling.Adds oldCallSid and oldCallType fields to the TelephonyResultEvent record to retain historical call identifiers and types. This change allows for enhanced tracking of call metadata.