### PR TITLE
feat: add taskWaitingUntil to TelephonyResultEvent for enhanced task …

### DIFF
--- a/core/src/main/java/com/tcn/exile/internal/ProtoConverter.java
+++ b/core/src/main/java/com/tcn/exile/internal/ProtoConverter.java
@@ -257,7 +257,8 @@ public final class ProtoConverter {
         toInstant(tr.getEndTime()),
         toTaskData(tr.getTaskDataList()),
         tr.hasOldCallSid() ? tr.getOldCallSid() : 0L,
-        tr.hasOldCallType() ? toCallType(tr.getOldCallType()) : null);
+        tr.hasOldCallType() ? toCallType(tr.getOldCallType()) : null,
+        tr.hasTaskWaitingUntil() ? toInstant(tr.getTaskWaitingUntil()) : null);
   }
 
   public static AgentResponseEvent toAgentResponseEvent(

--- a/core/src/main/java/com/tcn/exile/model/event/TelephonyResultEvent.java
+++ b/core/src/main/java/com/tcn/exile/model/event/TelephonyResultEvent.java
@@ -27,4 +27,5 @@ public record TelephonyResultEvent(
     Instant endTime,
     List<TaskData> taskData,
     long oldCallSid,
-    CallType oldCallType) {}
+    CallType oldCallType,
+    Instant taskWaitingUntil) {}


### PR DESCRIPTION
This pull request adds support for the new `taskWaitingUntil` field in the `TelephonyResultEvent` model and its conversion logic. The changes ensure that the event model and its converter can handle this additional timestamp, which may be used for tracking when a task is waiting until.

Model and conversion updates:

* Updated the `TelephonyResultEvent` record to include a new `Instant taskWaitingUntil` field.
* Modified the `ProtoConverter.toTelephonyResultEvent` method to extract and convert the `taskWaitingUntil` field from the protocol buffer, if present.…timing

Introduces the taskWaitingUntil attribute to the TelephonyResultEvent class, allowing tracking of when a task should wait until. This extends the existing functionality to better capture task scheduling details.